### PR TITLE
Add xAI (Grok) support

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Hourly scanner for OpenAI-compatible API endpoints with Discord notifications.
 | DeepInfra | `DEEPINFRA_API_KEY` | `https://api.deepinfra.com/v1/openai` |
 | Fireworks AI | `FIREWORKS_API_KEY` | `https://api.fireworks.ai/inference/v1` |
 | OpenRouter | `OPENROUTER_API_KEY` | `https://openrouter.ai/api/v1` |
+| xAI (Grok) | `XAI_API_KEY` | `https://api.x.ai/v1` |
 
 **Note:** GitHub Models requires a PAT (Personal Access Token) with `models` scope.
 

--- a/config.json
+++ b/config.json
@@ -84,6 +84,13 @@
       "apiKeyEnv": "ELEVENLABS_API_KEY",
       "modelsEndpoint": "/models",
       "group": "default"
+    },
+    {
+      "name": "xAI (Grok)",
+      "baseUrl": "https://api.x.ai/v1",
+      "apiKeyEnv": "XAI_API_KEY",
+      "modelsEndpoint": "/models",
+      "group": "small"
     }
   ],
   "scan": {


### PR DESCRIPTION
## Summary
- Added xAI (Grok) endpoint to config.json for monitoring Grok models
- Updated README.md with xAI in the supported endpoints table

## Details
- Endpoint: `https://api.x.ai/v1`
- Env variable: `XAI_API_KEY`
- Group: small (like other similar providers)

This adds support for scanning xAI's Grok models, as requested in issue #2.