### PR TITLE
fix: prevent fixupx.com being converted to fixupfixupx.com

### DIFF
--- a/src/rss-watch.js
+++ b/src/rss-watch.js
@@ -54,7 +54,13 @@ function saveState(statePath, state) {
  */
 function convertToFixupx(text) {
   if (!text) return '';
-  return text.replace(/fixupfixupx\.com\//g, 'fixupx.com/').replace(/rss\.fixupfixupx\.com\//g, 'fixupx.com/').replace(/nitter\.net\//g, 'fixupx.com/').replace(/xcancel\.com\//g, 'fixupx.com/').replace(/x\.com\//g, 'fixupx.com/').replace(/twitter\.com\//g, 'fixupx.com/');
+  // Use negative lookbehind to avoid converting fixupx.com to fixupfixupx.com
+  return text.replace(/fixupfixupx\.com\//g, 'fixupx.com/')
+    .replace(/rss\.fixupfixupx\.com\//g, 'fixupx.com/')
+    .replace(/nitter\.net\//g, 'fixupx.com/')
+    .replace(/xcancel\.com\//g, 'fixupx.com/')
+    .replace(/(?<!fixup)x\.com\//g, 'fixupx.com/')  // Only convert x.com if not preceded by 'fixup'
+    .replace(/twitter\.com\//g, 'fixupx.com/');
 }
 
 /**


### PR DESCRIPTION
## Summary
- Fixed the RSS watcher URL conversion bug that was incorrectly converting `fixupx.com` to `fixupfixupx.com`
- Used negative lookbehind regex `(?<!fixup)x\.com` to prevent matching `x.com` when it's preceded by `fixup`

## Root Cause
The original code had:
```javascript
.replace(/x\.com\//g, 'fixupx.com/')
```

This regex matches `x.com` in `fixupx.com`, causing:
- `nitter.net` → `fixupx.com` → `fixupfixupx.com` ❌

## Fix
```javascript
.replace(/(?<!fixup)x\.com\//g, 'fixupx.com/')
```

Now:
- `nitter.net` → `fixupx.com` ✓
- `x.com` → `fixupx.com` ✓
- `fixupx.com` → `fixupx.com` (preserved) ✓

## Testing
All test cases pass:
- `nitter.net` → `fixupx.com` ✓
- `xcancel.com` → `fixupx.com` ✓
- `fixupx.com` → `fixupx.com` ✓
- `fixupfixupx.com` → `fixupx.com` ✓
- `x.com` → `fixupx.com` ✓
- `twitter.com` → `fixupx.com` ✓