### PR TITLE
Fix: Only commit state.json, not timestamped scan files

### DIFF
--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -103,8 +103,8 @@ jobs:
           fi
           
           # Add and commit (only if there are changes)
-          # Force add logs folder since it's gitignored
-          git add -f logs/ || true
+          # Force add only state.json since scan files have timestamps
+          git add -f logs/state.json || true
           if ! git diff --quiet --staged; then
             git commit -m "Update logs - $(date -u +'%Y-%m-%d %H:%M UTC')"
             git push origin master


### PR DESCRIPTION
## Summary
- Fix the `scan.yml` workflow to only commit `logs/state.json` instead of all files in the logs folder
- This prevents unnecessary commits with only timestamp changes from timestamped scan log files (e.g., `scan-2026-02-21T22-15-47-985Z.json`)
- The `rss-watch.yml` workflow already does this correctly - only commits `rss-state.json`

## Changes
- Line 107: Changed `git add -f logs/` to `git add -f logs/state.json`

This fix was previously applied in PR #11 but was reverted in PR #12. This version re-applies the same fix.