### PR TITLE
Fix: Remove timestamp from state.json to prevent unnecessary commits

### DIFF
--- a/src/logger.js
+++ b/src/logger.js
@@ -68,7 +68,6 @@ export class Logger {
    */
   saveState(results) {
     const state = {
-      timestamp: new Date().toISOString(),
       endpoints: {}
     };
 


### PR DESCRIPTION
## Summary
- Removes the `timestamp` field from `state.json` to prevent commits when only the timestamp changes
- The timestamp was changing on every scan run, causing the hash comparison in the workflow to always fail and trigger commits even when no model data actually changed

## Root Cause
In `src/logger.js`, the `saveState()` method was writing a `timestamp` field to `state.json` on every scan:
```javascript
const state = {
  timestamp: new Date().toISOString(),  // <-- This changed every run
  endpoints: {}
};
```

The workflow already had hash comparison logic to detect actual changes, but since the timestamp always differed, it always triggered a commit.

## Fix
Simply remove the `timestamp` field from the saved state since it's not meaningful data - only the model list matters for change detection.