### PR TITLE
Add GitHub/npm releases watcher

### DIFF
--- a/.github/workflows/releases-watch.yml
+++ b/.github/workflows/releases-watch.yml
@@ -1,0 +1,80 @@
+name: Releases Watcher
+
+on:
+  schedule:
+    # Run every 30 minutes
+    - cron: '*/30 * * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          token: ${{ github.token }}
+          fetch-depth: 1
+          
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          
+      - name: Install dependencies
+        run: npm ci
+        
+      - name: Ensure logs folder exists
+        run: mkdir -p logs
+        
+      - name: Run releases scan
+        env:
+          RELEASES_WEBHOOK: ${{ secrets.RELEASES_WEBHOOK }}
+        run: npm run releases
+        
+      - name: Commit results to master
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Configure git with token
+          git config --global user.name "ModelWatcher"
+          git config --global user.email "modelwatcher@github.com"
+          
+          # Save the new state before resetting
+          cp logs/releases-state.json /tmp/releases-state-new.json 2>/dev/null || true
+          
+          # Fetch latest and reset
+          git fetch origin master
+          git reset --hard origin/master
+          
+          # Create logs dir and copy new state if we have one
+          mkdir -p logs
+          if [ -f /tmp/releases-state-new.json ]; then
+            cp /tmp/releases-state-new.json logs/releases-state.json
+          fi
+          
+          # Check if there are actual changes to commit
+          if [ -f logs/releases-state.json ]; then
+            ORIG_HASH=$(git show origin/master:logs/releases-state.json 2>/dev/null | sha256sum | cut -d' ' -f1 || echo "empty")
+            NEW_HASH=$(sha256sum logs/releases-state.json | cut -d' ' -f1)
+            if [ "$ORIG_HASH" = "$NEW_HASH" ] && [ "$ORIG_HASH" != "empty" ]; then
+              echo "No release changes detected - skipping commit"
+              exit 0
+            fi
+          fi
+          
+          # Add and commit (only if there are changes)
+          git add -f logs/releases-state.json || true
+          if ! git diff --quiet --staged; then
+            git commit -m "Update releases state - $(date -u +'%Y-%m-%d %H:%M UTC')"
+            git push origin master
+            echo "Updated releases state on master branch"
+          else
+            echo "No changes to commit"
+          fi

--- a/README.md
+++ b/README.md
@@ -1,52 +1,50 @@
 # Model Watcher
 
-Hourly scanner for OpenAI-compatible API endpoints with Discord notifications.
+ scanners for AI APIs, USPTO trademarks, and releases with Discord notifications.
 
 ## Features
 
-- Scans multiple OpenAI-compatible APIs hourly
-- Detects new, removed, and updated models
-- Sends Discord notifications via webhook (with group support)
+- **API Scanner** - Scans multiple OpenAI-compatible APIs hourly, detects new/removed/updated models
+- **USPTO Watcher** - Tracks trademark filings from tech companies
+- **Releases Watcher** - Tracks GitHub releases and npm package updates
+- **RSS/X Watcher** - Monitors RSS feeds and X.com accounts
+- Discord notifications via webhooks (with group support)
 - JSON logging with full change diffs
 - API key sanitization in all logs
 
-## Supported Endpoints
+## Trackers
 
-| Provider | Env Variable | Base URL |
-|----------|--------------|----------|
-| OpenAI | `OPENAI_API_KEY` | `https://api.openai.com/v1` |
-| Anthropic | `ANTHROPIC_API_KEY` | `https://api.anthropic.com/v1` |
-| Google Gemini | `GEMINI_API_KEY` | `https://generativelanguage.googleapis.com/v1beta/openai` |
-| GitHub Models | `GH_MODELS_API_KEY` | `https://models.github.ai` |
-| Groq | `GROQ_API_KEY` | `https://api.groq.com/openai/v1` |
-| Mistral | `MISTRAL_API_KEY` | `https://api.mistral.ai/v1` |
-| Cohere | `COHERE_API_KEY` | `https://api.cohere.ai/v1` |
-| Together AI | `TOGETHER_API_KEY` | `https://api.together.ai/v1` |
-| DeepInfra | `DEEPINFRA_API_KEY` | `https://api.deepinfra.com/v1/openai` |
-| Fireworks AI | `FIREWORKS_API_KEY` | `https://api.fireworks.ai/inference/v1` |
-| OpenRouter | `OPENROUTER_API_KEY` | `https://openrouter.ai/api/v1` |
-| xAI (Grok) | `XAI_API_KEY` | `https://api.x.ai/v1` |
+### API Scanner (`npm run scan`)
+Scans OpenAI-compatible API endpoints for model changes.
 
-**Note:** GitHub Models requires a PAT (Personal Access Token) with `models` scope.
+### USPTO Watcher (`npm run uspto`)
+Tracks trademark filings from uspto.report. Requires `USPTO_WEBHOOK` secret.
+
+### Releases Watcher (`npm run releases`)
+Tracks GitHub releases and npm package updates. Requires `RELEASES_WEBHOOK` secret.
+
+### RSS/X Watcher (`npm run rss`, `npm run posts`)
+Monitors RSS feeds and X.com accounts.
 
 ## Quick Start
 
 1. **Fork or clone this repo**
 
 2. **Add secrets to GitHub** (Settings → Secrets and variables → Actions):
-   - `WEBHOOK` - Your main Discord webhook URL (for big providers)
-   - `WEBHOOK_SMALL` - Optional secondary webhook (for smaller providers)
-   - `OPENAI_API_KEY` - Your OpenAI API key
-   - Add any other API keys for providers you want to scan
+   - `WEBHOOK` - Discord webhook for API scanner
+   - `USPTO_WEBHOOK` - Discord webhook for USPTO tracker
+   - `RELEASES_WEBHOOK` - Discord webhook for releases tracker
+   - `RSS_WEBHOOK` - Discord webhook for RSS/X watcher
+   - API keys for providers you want to scan
 
-3. **Customize config.json** - Edit endpoints to add/remove providers
+3. **Customize config files** - Edit `config.json`, `uspto-config.json`, `releases-config.json`
 
 4. **Run manually** - Use GitHub Actions "Run workflow" button
 
 ## Configuration
 
+### API Scanner
 Edit `config.json`:
-
 ```json
 {
   "endpoints": [
@@ -57,60 +55,33 @@ Edit `config.json`:
       "modelsEndpoint": "/models",
       "group": "default"
     }
-  ],
-  "scan": {
-    "timeout": 30000,
-    "retryAttempts": 2,
-    "retryDelay": 1000
-  },
-  "logging": {
-    "outputDir": "./logs",
-    "historyDays": 30
-  },
-  "discord": {
-    "enabled": true,
-    "webhooks": {
-      "default": {
-        "webhookEnv": "WEBHOOK",
-        "notifyOn": ["new_model", "removed_model", "model_updated", "endpoint_error", "summary_with_changes"]
-      },
-      "small": {
-        "webhookEnv": "WEBHOOK_SMALL",
-        "notifyOn": ["new_model", "removed_model", "model_updated", "endpoint_error", "summary_with_changes"]
-      }
-    },
-    "url": "https://github.com/CloudWaddie/ModelWatcher"
-  }
+  ]
 }
 ```
 
-### Endpoint Groups
-
-Assign endpoints to webhook groups using the `group` field:
-
-- `default` - Uses the `default` webhook config
-- Any custom group name - Uses the matching webhook config
-
-### Notification Options
-
-`notifyOn` supports:
-- `new_model` - New models detected
-- `removed_model` - Models removed
-- `model_updated` - Model properties changed
-- `endpoint_error` - API endpoint errors
-- `summary_with_changes` - Send summary only when there are changes
-
-## Adding Custom Endpoints
-
-Add any OpenAI-compatible endpoint:
-
+### USPTO Watcher
+Edit `uspto-config.json`:
 ```json
 {
-  "name": "My Provider",
-  "baseUrl": "https://api.myprovider.com/v1",
-  "apiKeyEnv": "MY_PROVIDER_API_KEY",
-  "modelsEndpoint": "/models",
-  "group": "default"
+  "companies": [
+    { "name": "Google LLC", "slug": "Google-L-L-C" },
+    { "name": "OpenAI OpCo LLC", "slug": "Openai-Opco-L-L-C" }
+  ]
+}
+```
+
+### Releases Watcher
+Edit `releases-config.json`:
+```json
+{
+  "github": {
+    "repositories": [
+      { "owner": "openai", "repo": "openai-python" }
+    ]
+  },
+  "npm": {
+    "packages": ["openai", "anthropic"]
+  }
 }
 ```
 
@@ -120,11 +91,12 @@ Add any OpenAI-compatible endpoint:
 # Install dependencies
 npm install
 
-# Run locally (requires env vars)
-WEBHOOK=https://discord.com/api/webhooks/... \
-WEBHOOK_SMALL=https://discord.com/api/webhooks/... \
-OPENAI_API_KEY=sk-... \
-npm run scan
+# Run scanners (requires appropriate env vars)
+npm run scan        # API scanner
+npm run uspto       # USPTO tracker
+npm run releases    # GitHub/npm tracker
+npm run rss        # RSS watcher
+npm run posts      # X.com watcher
 ```
 
 ## Security

--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
     "posts": "node src/posts.js",
     "rss": "node src/rss-watch.js",
     "uspto": "node src/uspto-watch.js",
+    "releases": "node src/releases-watch.js",
+    "releases": "node src/releases-watch.js",
+    "uspto": "node src/uspto-watch.js",
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js"
   },
   "keywords": [

--- a/releases-config.json
+++ b/releases-config.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "./releases-config.schema.json",
+  "github": {
+    "repositories": [
+      {
+        "owner": "openai",
+        "repo": "openai-python"
+      },
+      {
+        "owner": "anthropics",
+        "repo": "anthropic-sdk-python"
+      },
+      {
+        "owner": "mistralai",
+        "repo": "mistralai"
+      },
+      {
+        "owner": "meta-llama",
+        "repo": "llama"
+      },
+      {
+        "owner": "deepseek-ai",
+        "repo": "deepseek-chat"
+      }
+    ]
+  },
+  "npm": {
+    "packages": [
+      "openai",
+      "anthropic",
+      "mistralai",
+      "@meta-llama/llama",
+      "deepseek-sdk"
+    ]
+  },
+  "webhook": {
+    "enabled": true,
+    "webhookEnv": "RELEASES_WEBHOOK"
+  },
+  "state": {
+    "file": "./logs/releases-state.json"
+  },
+  "scan": {
+    "intervalMinutes": 30,
+    "timeout": 30000
+  }
+}

--- a/src/releases-watch.js
+++ b/src/releases-watch.js
@@ -1,0 +1,236 @@
+import axios from 'axios';
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'fs';
+import { dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { sendDiscordWebhook } from './webhook.js';
+
+const LOGO_URL = 'https://raw.githubusercontent.com/CloudWaddie/ModelWatcher/master/logo.jpg';
+
+/**
+ * Load configuration from releases-config.json
+ */
+function loadConfig() {
+  const configPath = './releases-config.json';
+  const configContent = readFileSync(configPath, 'utf-8');
+  return JSON.parse(configContent);
+}
+
+/**
+ * Load state from state file
+ */
+function loadState(statePath) {
+  if (existsSync(statePath)) {
+    try {
+      return JSON.parse(readFileSync(statePath, 'utf-8'));
+    } catch (e) {
+      console.error('Failed to parse state file, starting fresh:', e.message);
+    }
+  }
+  return { github: {}, npm: {} };
+}
+
+/**
+ * Save state to state file
+ */
+function saveState(statePath, state) {
+  const dir = dirname(statePath);
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true });
+  }
+  writeFileSync(statePath, JSON.stringify(state, null, 2));
+}
+
+/**
+ * Fetch latest release from a GitHub repository
+ */
+async function fetchGitHubRelease(owner, repo) {
+  try {
+    const response = await axios.get(`https://api.github.com/repos/${owner}/${repo}/releases/latest`, {
+      timeout: 10000,
+      headers: {
+        'Accept': 'application/vnd.github+json',
+        'User-Agent': 'ModelWatcher/1.0'
+      }
+    });
+    
+    return {
+      owner,
+      repo,
+      name: response.data.name || response.data.tag_name,
+      tag: response.data.tag_name,
+      url: response.data.html_url,
+      published: response.data.published_at,
+      body: response.data.body?.substring(0, 500) || ''
+    };
+  } catch (error) {
+    console.error(`Failed to fetch ${owner}/${repo}:`, error.message);
+    return null;
+  }
+}
+
+/**
+ * Fetch latest version from npm package
+ */
+async function fetchNpmVersion(packageName) {
+  try {
+    const response = await axios.get(`https://registry.npmjs.org/${packageName}/latest`, {
+      timeout: 10000
+    });
+    
+    return {
+      package: packageName,
+      version: response.data.version,
+      name: response.data.name,
+      url: `https://www.npmjs.com/package/${packageName}`,
+      description: response.data.description?.substring(0, 200) || ''
+    };
+  } catch (error) {
+    console.error(`Failed to fetch npm ${packageName}:`, error.message);
+    return null;
+  }
+}
+
+/**
+ * Get Discord relative timestamp
+ */
+function getRelativeTimestamp() {
+  const unixSeconds = Math.floor(Date.now() / 1000);
+  return `<t:${unixSeconds}:R>`;
+}
+
+/**
+ * Create Discord message for new releases
+ */
+function createReleasesMessage(type, items) {
+  const embeds = [];
+  
+  for (const item of items) {
+    const embed = {
+      title: type === 'github' ? `${item.owner}/${item.repo}` : item.package,
+      description: type === 'github' 
+        ? `**${item.name}**\n${item.body}`
+        : `**v${item.version}**\n${item.description || ''}`,
+      url: item.url,
+      color: type === 'github' ? 0x238636 : 0xCB0000,
+      timestamp: new Date().toISOString(),
+      footer: {
+        text: type === 'github' ? 'GitHub Release' : 'npm Package',
+        icon_url: type === 'github' ? 'https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png' : 'https://www.npmjs.com/static/images/touchicons/open-graph.svg'
+      }
+    };
+    
+    embeds.push(embed);
+  }
+  
+  const typeLabel = type === 'github' ? 'GitHub Releases' : 'npm Packages';
+  
+  return {
+    username: 'Releases Watcher',
+    avatar_url: LOGO_URL,
+    content: `📦 **New ${typeLabel}**\n\nFound ${items.length} new release${items.length > 1 ? 's' : ''} ${getRelativeTimestamp()}!`,
+    embeds: embeds
+  };
+}
+
+/**
+ * Main function
+ */
+async function main() {
+  console.log('=== Releases Watcher (GitHub/npm) ===');
+  console.log('Starting release check...');
+
+  const config = loadConfig();
+  const statePath = config.state?.file || './logs/releases-state.json';
+  const state = loadState(statePath);
+
+  const webhookUrl = process.env[config.webhook?.webhookEnv];
+
+  if (!webhookUrl) {
+    console.error(`Webhook URL not configured (${config.webhook?.webhookEnv} env not set), exiting`);
+    process.exit(1);
+  }
+
+  let totalNewReleases = 0;
+
+  // Check GitHub releases
+  const github = config.github?.repositories || [];
+  console.log(`\nChecking ${github.length} GitHub repositories...`);
+  
+  const githubNewReleases = [];
+  
+  for (const repo of github) {
+    const release = await fetchGitHubRelease(repo.owner, repo.repo);
+    
+    if (!release) continue;
+    
+    const key = `${repo.owner}/${repo.repo}`;
+    
+    // Initialize state if needed
+    if (!state.github[key]) {
+      state.github[key] = { tag: null, version: null };
+    }
+    
+    // Check if new
+    const isNew = release.tag !== state.github[key].tag;
+    
+    if (isNew) {
+      console.log(`  ✨ New: ${key} - ${release.tag}`);
+      githubNewReleases.push(release);
+      state.github[key].tag = release.tag;
+    } else {
+      console.log(`  ✓ ${key} - ${release.tag} (no change)`);
+    }
+  }
+
+  // Check npm packages
+  const npm = config.npm?.packages || [];
+  console.log(`\nChecking ${npm.length} npm packages...`);
+  
+  const npmNewReleases = [];
+  
+  for (const packageName of npm) {
+    const pkg = await fetchNpmVersion(packageName);
+    
+    if (!pkg) continue;
+    
+    // Initialize state if needed
+    if (!state.npm[packageName]) {
+      state.npm[packageName] = null;
+    }
+    
+    // Check if new
+    const isNew = pkg.version !== state.npm[packageName];
+    
+    if (isNew) {
+      console.log(`  ✨ New: ${packageName} - v${pkg.version}`);
+      npmNewReleases.push(pkg);
+      state.npm[packageName] = pkg.version;
+    } else {
+      console.log(`  ✓ ${packageName} - v${pkg.version} (no change)`);
+    }
+  }
+
+  // Send notifications using shared webhook utility
+  if (githubNewReleases.length > 0) {
+    const message = createReleasesMessage('github', githubNewReleases);
+    await sendDiscordWebhook(webhookUrl, message);
+    totalNewReleases += githubNewReleases.length;
+  }
+  
+  if (npmNewReleases.length > 0) {
+    const message = createReleasesMessage('npm', npmNewReleases);
+    await sendDiscordWebhook(webhookUrl, message);
+    totalNewReleases += npmNewReleases.length;
+  }
+
+  // Save state
+  saveState(statePath, state);
+
+  console.log(`\n=== Release check complete: ${totalNewReleases} new releases ===`);
+}
+
+// Run main function
+main().catch(err => {
+  console.error('Fatal error:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Add releases tracker for GitHub repositories and npm packages
- Track 5 AI/ML GitHub repos: openai-python, anthropic-sdk-python, mistralai, llama, deepseek-chat
- Track 5 npm packages: openai, anthropic, mistralai, @meta-llama/llama, deepseek-sdk
- Send Discord webhook notifications with release details and descriptions
- Add GitHub Actions workflow for 30-minute scans

## Features
- Uses GitHub API for latest releases
- Uses npm registry API for latest package versions
- Sends rich Discord embeds with release notes
- Maintains state to only notify on new releases
- Separate webhook channel from other trackers