### PR TITLE
Fix: import join from path module in uspto-watch.js

### DIFF
--- a/src/uspto-watch.js
+++ b/src/uspto-watch.js
@@ -1,6 +1,6 @@
 import { Camoufox } from 'camoufox-js';
 import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'fs';
-import { dirname } from 'path';
+import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));


### PR DESCRIPTION
## Summary
- Fix `ReferenceError: join is not defined` error at line 14 in `src/uspto-watch.js`
- Added missing `join` import from the `path` module

The `loadConfig` function was using `join(__dirname, '..', 'uspto-config.json')` but `join` was never imported from `path`. Only `dirname` was imported.