### PR TITLE
Fix USPTO proxy: geoip=True and socks5 to http conversion

### DIFF
--- a/src/uspto-watch.js
+++ b/src/uspto-watch.js
@@ -26,8 +26,10 @@ function getProxyConfig() {
   // Parse proxy URL (supports: http://user:pass@host:port or socks5://user:pass@host:port)
   try {
     const url = new URL(proxyUrl);
+    // Convert socks5 to http for better browser compatibility
+    const protocol = url.protocol === 'socks5:' ? 'http:' : url.protocol;
     return {
-      server: `${url.protocol}//${url.host}`,
+      server: `${protocol}//${url.host}`,
       username: url.username,
       password: url.password
     };
@@ -197,6 +199,8 @@ async function fetchCompanyFilings(companySlug, maxRetries = 3) {
 
       const camoufoxOptions = {
         headless: useVirtualDisplay ? 'virtual' : true,
+        // geoip is heavily recommended when using proxies for proper geolocation routing
+        geoip: proxyConfig ? true : false,
         args: [
           '--no-sandbox',
           '--disable-setuid-sandbox',


### PR DESCRIPTION
## Summary

Fixes `NS_ERROR_UNKNOWN_PROXY_HOST` error when using Webshare.io proxy with the USPTO scraper.

## Changes

1. **Add `geoip: true` to camoufox options** - The camoufox-js warning explicitly recommends this when using proxies for proper geolocation routing

2. **Convert socks5:// to http://** - SOCKS5 proxies cause connection issues in GitHub Actions. Converting to HTTP proxy provides better compatibility.

## Error Before Fix
```
Using Webshare.io proxy: socks5://p.webshare.io:80
When using a proxy, it is heavily recommended that you pass \`geoip=True\`.
Attempt 2/3 failed: page.goto: NS_ERROR_UNKNOWN_PROXY_HOST
```

## Note
If using Webshare.io, the proxy URL format should be:
- HTTP: `http://username:password@us-ca.webshare.io:80`
- (The code automatically converts socks5:// to http:// for compatibility)