### PR TITLE
Invert proxy logic: use as fallback instead of default

### DIFF
--- a/src/uspto-watch.js
+++ b/src/uspto-watch.js
@@ -75,7 +75,7 @@ async function waitForCloudflareChallenge(page, timeout = 30000) {
       if (bodyText.includes('Just a moment')) {
         return { success: false, reason: 'cloudflare_stuck' };
       }
-    } catch {}
+    } catch (evalError) { console.log(`Could not evaluate page content after challenge timeout: ${evalError.message}`); }
     return { success: false, reason: 'timeout' };
   }
 }
@@ -241,12 +241,12 @@ async function fetchCompanyFilings(companySlug, maxRetries = 2) {
         console.log(`Cloudflare challenge did not clear: ${challengeResult.reason || 'unknown'}`);
         if (!needsProxyRetry && proxyAvailable) {
           needsProxyRetry = true;
-          throw new Error('cloudflare_stuck');
+          throw new Error(ERROR_REASONS.CLOUDFLARE_STUCK);
         } else if (needsProxyRetry && !proxyRetryFailed) {
           proxyRetryFailed = true;
-          throw new Error('proxy_failed');
+          throw new Error(ERROR_REASONS.PROXY_FAILED);
         }
-        throw new Error('unrecoverable');
+        throw new Error(ERROR_REASONS.UNRECOVERABLE);
       }
       
       await handleCaptcha(page);


### PR DESCRIPTION
## Summary
- Proxy is now a **fallback** instead of the default behavior
- First attempt always tries without proxy
- If stuck on "Just a moment..." or no results returned, retry with proxy
- If proxy not enabled or proxy fails, proceed without (move on)

## Changes

### `src/uspto-watch.js`

1. **`waitForCloudflareChallenge()`** - Returns `{success: boolean, reason?: string}` instead of just boolean, allowing callers to detect the specific failure reason

2. **`fetchCompanyFilings()`** - Complete rewrite of retry logic:
   - `needsProxyRetry` flag triggers proxy use on second attempt
   - Proxy only used when: cloudflare_stuck OR no_results AND proxyAvailable
   - Changed from `for` loop to `while` loop for clearer control flow
   - `maxRetries` reduced from 3 to 2 (one attempt without proxy, one with)

## New Flow

```
1. Attempt 1: No proxy
   ├── Success → return results
   ├── Cloudflare stuck OR no results → attempt 2
   └── Other error → retry attempt 1 (exponential backoff)
   
2. Attempt 2 (if needed): With proxy
   ├── Success → return results
   ├── Proxy fails → proceed without (return empty or error)
   └── Other error → proceed without
```

This matches the requested behavior: "By default, do NOT use a proxy. If stuck on 'Just a moment...' or we don't get any results back, proceed to step 3. If proxy enabled, use it for the rest of the workflow."