### PR TITLE
fix: remove deprecated setRequestInterception API call

### DIFF
--- a/src/regex-watch.js
+++ b/src/regex-watch.js
@@ -265,10 +265,8 @@ async function processUrl(page, url, patterns, timeout) {
   };
   
   try {
-    // Set up response interception
+    // Collect responses
     const responses = [];
-    
-    await page.setRequestInterception(true);
     
     page.on('response', async (response) => {
       try {


### PR DESCRIPTION
## Summary
- Remove deprecated `page.setRequestInterception()` API call that was causing errors in Camoufox

## Fix
The `page.setRequestInterception` method is deprecated and has been removed in modern versions. The code was calling it but never actually intercepting requests - it only listened to responses via `page.on('response')`, which works perfectly fine without request interception being enabled.

This fixes the error when processing Google Gemini:
```
page.setRequestInterception is not a function
```

## Changes
- Removed `await page.setRequestInterception(true);` from `src/regex-watch.js`