### PR TITLE
fix: handle string pattern format in regex watcher

### DIFF
--- a/src/regex-watch.js
+++ b/src/regex-watch.js
@@ -319,8 +319,8 @@ async function processUrl(page, url, patterns, timeout) {
     
     // Process each pattern
     for (const patternConfig of patterns) {
-      const patternId = patternConfig.id || patternConfig.pattern;
-      const pattern = patternConfig.pattern;
+      const pattern = typeof patternConfig === 'string' ? patternConfig : patternConfig.pattern;
+      const patternId = typeof patternConfig === 'string' ? patternConfig : (patternConfig.id || patternConfig.pattern);
       const hasCaptureGroups = /\((?!\?:)/.test(pattern);
       
       const matchedStrings = new Set();


### PR DESCRIPTION
## Summary
- Fix pattern matching when patterns are defined as simple strings in regex-config.json

## Root Cause
The regex-config.json uses simple string patterns:
```json
"patterns": ["gemini-3\\.[0-9]+"]
```

But the code expected objects with `.id` and `.pattern` properties:
```javascript
const patternId = patternConfig.id || patternConfig.pattern;  // undefined!
const pattern = patternConfig.pattern;  // undefined!
```

This caused:
1. `patternId` to be `undefined`
2. `pattern` to be `undefined`
3. `new RegExp(undefined)` matching the literal word "undefined" 1.6M times!

## Fix
Handle both string and object pattern formats:
```javascript
const pattern = typeof patternConfig === 'string' ? patternConfig : patternConfig.pattern;
const patternId = typeof patternConfig === 'string' ? patternConfig : (patternConfig.id || patternConfig.pattern);
```