### PR TITLE
fix: tighten regex patterns to avoid invalid matches

### DIFF
--- a/regex-config.json
+++ b/regex-config.json
@@ -4,22 +4,22 @@
     {
       "name": "Google Gemini - Gemini Models",
       "url": "https://gemini.google.com/",
-      "patterns": ["gemini-[0-9.]+"]
+      "patterns": ["gemini-[0-9]+(?:\\.[0-9]+)*"]
     },
     {
       "name": "ChatGPT - Model Names",
       "url": "https://chatgpt.com/",
-      "patterns": ["gpt-[0-9.]+"]
+      "patterns": ["gpt-[0-9]+(?:\\.[0-9]+)*"]
     },
     {
       "name": "Claude - Model Names",
       "url": "https://claude.ai/",
-      "patterns": ["claude-[a-z]+-[0-9.]+"]
+      "patterns": ["claude-[a-z]+-[0-9]+(?:\\.[0-9]+)*"]
     },
     {
       "name": "Grok - xAI Models",
       "url": "https://grok.com",
-      "patterns": ["grok-[0-9.]+"]
+      "patterns": ["grok-[0-9]+(?:\\.[0-9]+)*"]
     }
   ],
   "webhook": {


### PR DESCRIPTION
## Summary
- Fix overly permissive regex patterns that could match invalid strings

## Changes

| Pattern | Before | After |
|---------|--------|-------|
| Gemini | `gemini-[0-9.]+` | `gemini-[0-9]+(?:\.[0-9]+)*` |
| GPT | `gpt-[0-9.]+` | `gpt-[0-9]+(?:\.[0-9]+)*` |
| Claude | `claude-[a-z]+-[0-9.]+` | `claude-[a-z]+-[0-9]+(?:\.[0-9]+)*` |
| Grok | `grok-[0-9.]+` | `grok-[0-9]+(?:\.[0-9]+)*` |

## Why
The old patterns `[0-9.]+` would match invalid strings like `gemini-.` or `gpt-.`. The new patterns require at least one digit before any dot, preventing these invalid matches.

## Reference
Fixes review comment from `gemini-code-assist` on PR #41