### PR TITLE
fix: improve regex patterns to match model names like gpt-5.4 and gemini-3.1-flash-preview

### DIFF
--- a/regex-config.json
+++ b/regex-config.json
@@ -4,12 +4,12 @@
     {
       "name": "Google Gemini - Gemini Models",
       "url": "https://gemini.google.com/",
-      "patterns": ["gemini-[0-9]+(?:[a-z0-9.-]+)?(?:\\\\.[0-9]+)*"]
+      "patterns": ["gemini-[0-9]+(?:[a-z0-9.-]+)*"]
     },
     {
       "name": "ChatGPT - Model Names",
       "url": "https://chatgpt.com/",
-      "patterns": ["gpt-[0-9]+(?:[a-z0-9.-]+)?(?:\\\\.[0-9]+)*"]
+      "patterns": ["gpt-[0-9]+(?:[a-z0-9.-]+)*"]
     },
     {
       "name": "Claude - Model Names",


### PR DESCRIPTION
## Summary
- Update gemini and gpt regex patterns to allow dots and hyphens in the optional middle section
- Now correctly matches model names like `gpt-5.4` and `gemini-3.1-flash-preview`