### PR TITLE
Send full URL in DeepMind model card notifications

### DIFF
--- a/src/deepmind-watch.js
+++ b/src/deepmind-watch.js
@@ -182,7 +182,7 @@ function createNewCardsEmbed(newCards) {
   
   for (let i = 0; i < newCards.length; i += maxPerField) {
     const chunk = newCards.slice(i, i + maxPerField);
-    const cardList = chunk.map(c => c.filename).join('\n');
+    const cardList = chunk.map(c => c.url).join('\n');
     const label = newCards.length > maxPerField 
       ? `New Cards (${i + 1}-${Math.min(i + maxPerField, newCards.length)})`
       : 'New Model Cards';

--- a/src/deepmind-watch.js
+++ b/src/deepmind-watch.js
@@ -182,6 +182,8 @@ function createNewCardsEmbed(newCards) {
   
   for (let i = 0; i < newCards.length; i += maxPerField) {
     const chunk = newCards.slice(i, i + maxPerField);
+  for (let i = 0; i < newCards.length; i += 5) {
+    const chunk = newCards.slice(i, i + 5);
     const cardList = chunk.map(c => c.url).join('\n');
     const label = newCards.length > maxPerField 
       ? `New Cards (${i + 1}-${Math.min(i + maxPerField, newCards.length)})`


### PR DESCRIPTION
Changed Discord notification to send full URLs instead of just filenames

Before: Notifications showed only filenames like Gemini-4-Pro-Model-Card.pdf
After: Notifications now show full URLs like https://storage.googleapis.com/deepmind-media/Model-Cards/Gemini-4-Pro-Model-Card.pdf

This makes it easier for users to click through directly to the model cards.