### PR TITLE
fix: harden discord webhook payload limits

### DIFF
--- a/src/bedrock-watch.js
+++ b/src/bedrock-watch.js
@@ -102,94 +102,55 @@ function diffModels(oldModels, newModels) {
 
 function endpointEmoji(val) { return val ? '✅' : '❌'; }
 
-function buildNotification(diff, total) {
-  const components = [];
-  const headerLines = [];
-
-  headerLines.push('# 🏔️ AWS Bedrock — Model Changes');
-  headerLines.push(`Total tracked: **${total}**`);
-
-  components.push({ type: 10, content: headerLines.join('\n') });
-
-  const DISCORD_COMPONENT_LIMIT = 2000;
-
-  if (diff.added.length > 0) {
-    components.push({ type: 14 });
-    components.push({ type: 10, content: `## 🆕 New Models (${diff.added.length})` });
-    const byProv = {};
-    for (const m of diff.added) {
-      if (!byProv[m.provider]) byProv[m.provider] = [];
-      byProv[m.provider].push(m);
-    }
-    for (const [prov, ms] of Object.entries(byProv)) {
-      let currentContent = `**${prov}**\n`;
-      for (const m of ms) {
-        const line = `${m.name} — ${endpointEmoji(m.runtime)} runtime · ${endpointEmoji(m.mantle)} mantle\n`;
-        if (currentContent.length + line.length > DISCORD_COMPONENT_LIMIT - 100) {
-          components.push({ type: 10, content: currentContent.trim() });
-          currentContent = `**${prov} (cont.)**\n`;
-        }
-        currentContent += line;
-      }
-      components.push({ type: 10, content: currentContent.trim() });
-    }
-  }
-
-  if (diff.removed.length > 0) {
-    components.push({ type: 14 });
-    components.push({ type: 10, content: `## 🗑️ Removed Models (${diff.removed.length})` });
-    const byProv = {};
-    for (const m of diff.removed) {
-      if (!byProv[m.provider]) byProv[m.provider] = [];
-      byProv[m.provider].push(m);
-    }
-    for (const [prov, ms] of Object.entries(byProv)) {
-      let currentContent = `**${prov}**\n`;
-      for (const m of ms) {
-        const line = `${m.name}\n`;
-        if (currentContent.length + line.length > DISCORD_COMPONENT_LIMIT - 100) {
-          components.push({ type: 10, content: currentContent.trim() });
-          currentContent = `**${prov} (cont.)**\n`;
-        }
-        currentContent += line;
-      }
-      components.push({ type: 10, content: currentContent.trim() });
-    }
-  }
-
-  if (diff.changed.length > 0) {
-    components.push({ type: 14 });
-    components.push({ type: 10, content: `## 🔄 Endpoint Changes (${diff.changed.length})` });
-    const byProv = {};
-    for (const c of diff.changed) {
-      if (!byProv[c.model.provider]) byProv[c.model.provider] = [];
-      byProv[c.model.provider].push(c);
-    }
-    for (const [prov, cs] of Object.entries(byProv)) {
-      let currentContent = `**${prov}**\n`;
-      for (const c of cs) {
-        const m = c.model;
-        const o = c.old;
-        const parts = [];
-        if (o.runtime !== m.runtime) parts.push(`runtime: ${endpointEmoji(o.runtime)} → ${endpointEmoji(m.runtime)}`);
-        if (o.mantle !== m.mantle) parts.push(`mantle: ${endpointEmoji(o.mantle)} → ${endpointEmoji(m.mantle)}`);
-        const line = `${m.name} — ${parts.join(', ')}\n`;
-        if (currentContent.length + line.length > DISCORD_COMPONENT_LIMIT - 100) {
-          components.push({ type: 10, content: currentContent.trim() });
-          currentContent = `**${prov} (cont.)**\n`;
-        }
-        currentContent += line;
-      }
-      components.push({ type: 10, content: currentContent.trim() });
-    }
-  }
-
-  return {
+function buildNotifications(diff, total) {
+  const payloads = [];
+  const common = {
     username: 'Bedrock Watcher',
     avatar_url: LOGO_URL,
     flags: 32768,
-    components: [{ type: 17, components }],
   };
+
+  const header = `# 🏔️ AWS Bedrock — Model Changes\nTotal tracked: **${total}**`;
+  payloads.push({ ...common, components: [{ type: 17, components: [{ type: 10, content: header }] }] });
+
+  const DISCORD_LIMIT = 2000;
+
+  const processSection = (title, items, lineBuilder) => {
+    if (items.length === 0) return;
+    
+    payloads.push({ ...common, components: [{ type: 17, components: [{ type: 10, content: `## ${title} (${items.length})` }] }] });
+    
+    const byProv = {};
+    for (const item of items) {
+      const provider = item.provider || item.model.provider;
+      if (!byProv[provider]) byProv[provider] = [];
+      byProv[provider].push(item);
+    }
+
+    for (const [prov, ms] of Object.entries(byProv)) {
+      let currentContent = `**${prov}**\n`;
+      for (const m of ms) {
+        const line = lineBuilder(m);
+        if (currentContent.length + line.length > DISCORD_LIMIT - 50) {
+          payloads.push({ ...common, components: [{ type: 17, components: [{ type: 10, content: currentContent.trim() }] }] });
+          currentContent = `**${prov} (cont.)**\n`;
+        }
+        currentContent += line;
+      }
+      payloads.push({ ...common, components: [{ type: 17, components: [{ type: 10, content: currentContent.trim() }] }] });
+    }
+  };
+
+  processSection('🆕 New Models', diff.added, m => `${m.name} — ${endpointEmoji(m.runtime)} runtime · ${endpointEmoji(m.mantle)} mantle\n`);
+  processSection('🗑️ Removed Models', diff.removed, m => `${m.name}\n`);
+  processSection('🔄 Endpoint Changes', diff.changed, c => {
+    const parts = [];
+    if (c.old.runtime !== c.model.runtime) parts.push(`runtime: ${endpointEmoji(c.old.runtime)} → ${endpointEmoji(c.model.runtime)}`);
+    if (c.old.mantle !== c.model.mantle) parts.push(`mantle: ${endpointEmoji(c.old.mantle)} → ${endpointEmoji(c.model.mantle)}`);
+    return `${c.model.name} — ${parts.join(', ')}\n`;
+  });
+
+  return payloads;
 }
 
 async function main() {
@@ -202,38 +163,32 @@ async function main() {
   console.log('Fetching model availability page...');
   const md = await fetchMarkdown(config.scan.url, config.scan.timeout);
   const models = parseModels(md);
-  console.log(`Parsed ${models.length} models from ${new Set(models.map(m => m.provider)).size} providers`);
 
   const diff = diffModels(prevState.models, models);
   const hasChanges = diff.added.length > 0 || diff.removed.length > 0 || diff.changed.length > 0;
 
   if (!hasChanges && prevState.models.length > 0) {
-    console.log('No changes detected');
     saveState(statePath, { models, timestamp: Date.now() });
     return;
   }
 
   if (prevState.models.length === 0) {
-    console.log('First run — saving baseline');
     saveState(statePath, { models, timestamp: Date.now() });
     return;
   }
 
-  console.log(`Changes: +${diff.added.length} new, -${diff.removed.length} removed, ~${diff.changed.length} updated`);
-
   if (webhookUrl) {
-    const payload = buildNotification(diff, models.length);
-    const res = await fetch(webhookUrl + '?with_components=true', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(payload),
-    });
-    if (res.ok) console.log('Discord notification sent');
-    else console.error('Discord send failed:', res.status, await res.text());
+    const payloads = buildNotifications(diff, models.length);
+    for (const payload of payloads) {
+      await fetch(webhookUrl + '?with_components=true', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+    }
   }
 
   saveState(statePath, { models, timestamp: Date.now() });
-  console.log(`=== Bedrock scan complete: ${models.length} models ===`);
 }
 
 main().catch(err => {

--- a/src/bedrock-watch.js
+++ b/src/bedrock-watch.js
@@ -104,12 +104,14 @@ function endpointEmoji(val) { return val ? '✅' : '❌'; }
 
 function buildNotification(diff, total) {
   const components = [];
-  const lines = [];
+  const headerLines = [];
 
-  lines.push('# 🏔️ AWS Bedrock — Model Changes');
-  lines.push(`Total tracked: **${total}**`);
+  headerLines.push('# 🏔️ AWS Bedrock — Model Changes');
+  headerLines.push(`Total tracked: **${total}**`);
 
-  components.push({ type: 10, content: lines.join('\n') });
+  components.push({ type: 10, content: headerLines.join('\n') });
+
+  const DISCORD_COMPONENT_LIMIT = 2000;
 
   if (diff.added.length > 0) {
     components.push({ type: 14 });
@@ -120,10 +122,16 @@ function buildNotification(diff, total) {
       byProv[m.provider].push(m);
     }
     for (const [prov, ms] of Object.entries(byProv)) {
-      const entries = ms.map(m =>
-        `${m.name} — ${endpointEmoji(m.runtime)} runtime · ${endpointEmoji(m.mantle)} mantle`
-      ).join('\n');
-      components.push({ type: 10, content: `**${prov}**\n${entries}` });
+      let currentContent = `**${prov}**\n`;
+      for (const m of ms) {
+        const line = `${m.name} — ${endpointEmoji(m.runtime)} runtime · ${endpointEmoji(m.mantle)} mantle\n`;
+        if (currentContent.length + line.length > DISCORD_COMPONENT_LIMIT - 100) {
+          components.push({ type: 10, content: currentContent.trim() });
+          currentContent = `**${prov} (cont.)**\n`;
+        }
+        currentContent += line;
+      }
+      components.push({ type: 10, content: currentContent.trim() });
     }
   }
 
@@ -136,7 +144,16 @@ function buildNotification(diff, total) {
       byProv[m.provider].push(m);
     }
     for (const [prov, ms] of Object.entries(byProv)) {
-      components.push({ type: 10, content: `**${prov}**\n${ms.map(m => m.name).join('\n')}` });
+      let currentContent = `**${prov}**\n`;
+      for (const m of ms) {
+        const line = `${m.name}\n`;
+        if (currentContent.length + line.length > DISCORD_COMPONENT_LIMIT - 100) {
+          components.push({ type: 10, content: currentContent.trim() });
+          currentContent = `**${prov} (cont.)**\n`;
+        }
+        currentContent += line;
+      }
+      components.push({ type: 10, content: currentContent.trim() });
     }
   }
 
@@ -149,19 +166,23 @@ function buildNotification(diff, total) {
       byProv[c.model.provider].push(c);
     }
     for (const [prov, cs] of Object.entries(byProv)) {
-      const entries = cs.map(c => {
+      let currentContent = `**${prov}**\n`;
+      for (const c of cs) {
         const m = c.model;
         const o = c.old;
         const parts = [];
         if (o.runtime !== m.runtime) parts.push(`runtime: ${endpointEmoji(o.runtime)} → ${endpointEmoji(m.runtime)}`);
         if (o.mantle !== m.mantle) parts.push(`mantle: ${endpointEmoji(o.mantle)} → ${endpointEmoji(m.mantle)}`);
-        return `${m.name} — ${parts.join(', ')}`;
-      }).join('\n');
-      components.push({ type: 10, content: `**${prov}**\n${entries}` });
+        const line = `${m.name} — ${parts.join(', ')}\n`;
+        if (currentContent.length + line.length > DISCORD_COMPONENT_LIMIT - 100) {
+          components.push({ type: 10, content: currentContent.trim() });
+          currentContent = `**${prov} (cont.)**\n`;
+        }
+        currentContent += line;
+      }
+      components.push({ type: 10, content: currentContent.trim() });
     }
   }
-
-
 
   return {
     username: 'Bedrock Watcher',

--- a/src/regex-watch.js
+++ b/src/regex-watch.js
@@ -12,18 +12,11 @@ const DEFAULT_TIMEOUT = 60000;
 const DEFAULT_DELAY = 2500;
 const REGEX_TIMEOUT = 10000;
 
-/**
- * Load configuration from regex-config.json
- */
 function loadConfig() {
   const configPath = join(__dirname, '..', 'regex-config.json');
-  const configContent = readFileSync(configPath, 'utf-8');
-  return JSON.parse(configContent);
+  return JSON.parse(readFileSync(configPath, 'utf-8'));
 }
 
-/**
- * Validate URL format
- */
 function isValidUrl(url) {
   try {
     const parsed = new URL(url);
@@ -33,38 +26,18 @@ function isValidUrl(url) {
   }
 }
 
-/**
- * Validate all URLs in config on startup
- */
 function validateUrls(config) {
   const pages = config.pages || [];
-  const invalidUrls = [];
-  
   for (const page of pages) {
-    if (!page.url || !isValidUrl(page.url)) {
-      invalidUrls.push({ name: page.name, url: page.url });
-    }
+    if (!page.url || !isValidUrl(page.url)) return false;
   }
-  
-  if (invalidUrls.length > 0) {
-    console.error('Invalid URLs found in config:');
-    for (const invalid of invalidUrls) {
-      console.error(`  - ${invalid.name}: ${invalid.url}`);
-    }
-    return false;
-  }
-  
   return true;
 }
 
-/**
- * Load state from state file
- */
 function loadState(statePath) {
   if (existsSync(statePath)) {
     try {
       const data = JSON.parse(readFileSync(statePath, 'utf-8'));
-      // Convert arrays back to Sets for matchedStrings
       for (const url in data) {
         if (data[url] && data[url].patterns) {
           for (const patternId in data[url].patterns) {
@@ -82,15 +55,9 @@ function loadState(statePath) {
   return {};
 }
 
-/**
- * Save state to state file
- */
 function saveState(statePath, state) {
   const dir = dirname(statePath);
-  if (!existsSync(dir)) {
-    mkdirSync(dir, { recursive: true });
-  }
-  // Convert Sets to arrays for JSON serialization
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
   const stateToSave = {};
   for (const url in state) {
     stateToSave[url] = { patterns: {} };
@@ -108,45 +75,23 @@ function saveState(statePath, state) {
   writeFileSync(statePath, JSON.stringify(stateToSave, null, 2));
 }
 
-/**
- * Check if response is binary based on content-type
- */
 function isBinaryResponse(contentType) {
   if (!contentType) return false;
-  const binaryTypes = [
-    'image/',
-    'application/pdf',
-    'application/zip',
-    'application/gzip',
-    'application/octet-stream',
-    'audio/',
-    'video/'
-  ];
+  const binaryTypes = ['image/', 'application/pdf', 'application/zip', 'application/gzip', 'application/octet-stream', 'audio/', 'video/'];
   return binaryTypes.some(type => contentType.toLowerCase().startsWith(type));
 }
 
-/**
- * Run regex pattern with timeout
- */
 function runRegexWithTimeout(pattern, text, timeout = REGEX_TIMEOUT) {
   return new Promise((resolve, reject) => {
-    const timer = setTimeout(() => {
-      reject(new Error('Regex timeout'));
-    }, timeout);
-    
+    const timer = setTimeout(() => reject(new Error('Regex timeout')), timeout);
     try {
       const regex = new RegExp(pattern, 'gi');
       const matches = [];
       let match;
-      
       while ((match = regex.exec(text)) !== null) {
         matches.push(match[0]);
-        // Prevent infinite loops on zero-length matches
-        if (match[0].length === 0) {
-          regex.lastIndex++;
-        }
+        if (match[0].length === 0) regex.lastIndex++;
       }
-      
       clearTimeout(timer);
       resolve(matches);
     } catch (e) {
@@ -156,278 +101,140 @@ function runRegexWithTimeout(pattern, text, timeout = REGEX_TIMEOUT) {
   });
 }
 
-/**
- * Extract capture groups from regex matches
- */
 function extractCaptureGroups(pattern, text) {
   const results = [];
   try {
     const regex = new RegExp(pattern, 'gi');
     let match;
-    
     while ((match = regex.exec(text)) !== null) {
-      // If there are capture groups, extract them
       if (match.length > 1) {
-        for (let i = 1; i < match.length; i++) {
-          if (match[i]) {
-            results.push(match[i]);
-          }
-        }
+        for (let i = 1; i < match.length; i++) if (match[i]) results.push(match[i]);
       } else {
-        // No capture groups, use the full match
         results.push(match[0]);
       }
-      
-      // Prevent infinite loops on zero-length matches
-      if (match[0].length === 0) {
-        regex.lastIndex++;
-      }
+      if (match[0].length === 0) regex.lastIndex++;
     }
-  } catch (e) {
-    console.error('Regex extraction error:', e.message);
-  }
-  
+  } catch (e) {}
   return results;
 }
 
-/**
- * Check if a string looks like binary content
- */
 function looksLikeBinary(text) {
-  // Check for null bytes or high concentration of non-printable characters
   if (!text) return false;
   const sample = text.slice(0, 1000);
   const nonPrintable = sample.split('').filter(char => {
     const code = char.charCodeAt(0);
     return code < 32 && char !== '\n' && char !== '\r' && char !== '\t';
   }).length;
-  
   return nonPrintable / sample.length > 0.1;
 }
 
-/**
- * Launch Camoufox browser with retry logic
- */
 async function launchBrowser(maxRetries = 2) {
   let lastError;
-  let attempt = 0;
-  
-  while (attempt < maxRetries) {
-    attempt++;
+  for (let attempt = 1; attempt <= maxRetries; attempt++) {
     let browser;
-    
     try {
-      const camoufoxOptions = {
-        headless: true,
-        args: [
-          '--no-sandbox',
-          '--disable-setuid-sandbox',
-          '--disable-dev-shm-usage',
-          '--disable-gpu'
-        ]
-      };
-      
-      browser = await Camoufox(camoufoxOptions);
+      browser = await Camoufox({ headless: true, args: ['--no-sandbox', '--disable-setuid-sandbox', '--disable-dev-shm-usage', '--disable-gpu'] });
       return browser;
-      
     } catch (error) {
       lastError = error;
-      console.error(`Browser launch attempt ${attempt} failed:`, error.message);
-      
-      if (browser) {
-        try {
-          await browser.close();
-        } catch (closeError) {
-          // Ignore close errors
-        }
-      }
-      
-      if (attempt < maxRetries) {
-        const delay = Math.pow(2, attempt) * 1000;
-        console.log(`Retrying browser launch in ${delay / 1000} seconds...`);
-        await new Promise(resolve => setTimeout(resolve, delay));
-      }
+      if (browser) await browser.close().catch(() => {});
+      if (attempt < maxRetries) await new Promise(resolve => setTimeout(resolve, Math.pow(2, attempt) * 1000));
     }
   }
-  
-  console.error('All browser launch attempts failed:', lastError?.message);
   throw lastError;
 }
 
-/**
- * Process a single URL - navigate and extract regex matches
- */
 async function processUrl(page, url, patterns, timeout) {
-  const results = {
-    url,
-    success: false,
-    patterns: {}
-  };
-  
+  const results = { url, success: false, patterns: {} };
   try {
     const responses = [];
     const pendingHandlers = [];
-    
     const responseHandler = async (response) => {
       const handlerPromise = (async () => {
         try {
           const contentType = response.headers()['content-type'] || '';
-          const status = response.status();
-          
-          if (status < 200 || status >= 300) return;
+          if (response.status() < 200 || response.status() >= 300) return;
           if (!contentType.includes('text/html') && !contentType.includes('text/plain')) return;
           if (isBinaryResponse(contentType)) return;
-          
-          let body;
-          try {
-            body = await response.text();
-          } catch (e) {
-            return;
-          }
-          
-          if (body.length > MAX_RESPONSE_SIZE) {
-            body = body.slice(0, MAX_RESPONSE_SIZE);
-          }
-          
-          if (looksLikeBinary(body)) return;
-          
-          responses.push(body);
-        } catch (e) {
-        }
+          let body = await response.text();
+          if (body.length > MAX_RESPONSE_SIZE) body = body.slice(0, MAX_RESPONSE_SIZE);
+          if (!looksLikeBinary(body)) responses.push(body);
+        } catch (e) {}
       })();
       pendingHandlers.push(handlerPromise);
     };
-    
     page.on('response', responseHandler);
-    
-    await page.goto(url, {
-      waitUntil: 'domcontentloaded',
-      timeout
-    });
-    
+    await page.goto(url, { waitUntil: 'domcontentloaded', timeout });
     await page.waitForLoadState('networkidle', { timeout: 5000 }).catch(() => {});
-    
     page.removeListener('response', responseHandler);
     await Promise.all(pendingHandlers);
-    
-    const pageContent = await page.content();
-    responses.push(pageContent);
-    
-    // Process each pattern
+    responses.push(await page.content());
+
     for (const patternConfig of patterns) {
       const pattern = typeof patternConfig === 'string' ? patternConfig : patternConfig.pattern;
       const patternId = typeof patternConfig === 'string' ? patternConfig : (patternConfig.id || patternConfig.pattern);
       const hasCaptureGroups = /\((?!\?:)/.test(pattern);
-      
       const matchedStrings = new Set();
       let matchCount = 0;
-      
-      // Run regex on all collected responses
       for (const body of responses) {
         try {
-          let matches;
-          
-          if (hasCaptureGroups) {
-            // Extract capture groups
-            matches = extractCaptureGroups(pattern, body);
-          } else {
-            // Run simple regex
-            matches = await runRegexWithTimeout(pattern, body);
-          }
-          
-          for (const match of matches) {
-            matchedStrings.add(match);
-          }
-          
+          const matches = hasCaptureGroups ? extractCaptureGroups(pattern, body) : await runRegexWithTimeout(pattern, body);
+          for (const m of matches) matchedStrings.add(m);
           matchCount += matches.length;
-        } catch (e) {
-          console.error(`Regex error for pattern ${patternId}:`, e.message);
-        }
+        } catch (e) {}
       }
-      
-      results.patterns[patternId] = {
-        count: matchCount,
-        matchedStrings: Array.from(matchedStrings),
-        uniqueCount: matchedStrings.size,
-        timestamp: Date.now()
-      };
+      results.patterns[patternId] = { count: matchCount, matchedStrings: Array.from(matchedStrings), uniqueCount: matchedStrings.size, timestamp: Date.now() };
     }
-    
     results.success = true;
-    
   } catch (error) {
     results.error = error.message;
-    console.error(`Error processing ${url}:`, error.message);
   }
-  
   return results;
 }
 
-/**
- * Send a Discord webhook notification
- */
 async function sendDiscordWebhook(webhookUrl, payload) {
-  if (!webhookUrl) {
-    console.log('Discord webhook URL not configured, skipping notification');
-    return false;
-  }
-
-  const { default: axios } = await import('axios');
-  const { safeEmbed } = await import('./webhook.js');
-  
-  try {
-    await axios.post(webhookUrl, safeEmbed(payload), {
-      headers: { 'Content-Type': 'application/json' }
-    });
-    return true;
-  } catch (err) {
-    const details = err.response?.data ? JSON.stringify(err.response.data) : err.message;
-    console.error('Failed to send Discord webhook:', err.response?.status, details);
-    return false;
-  }
+  const { sendDiscordWebhook: send } = await import('./webhook.js');
+  return send(webhookUrl, payload);
 }
 
-/**
- * Get Discord relative timestamp
- */
 function getRelativeTimestamp() {
-  const unixSeconds = Math.floor(Date.now() / 1000);
-  return `<t:${unixSeconds}:R>`;
+  return `<t:\${Math.floor(Date.now() / 1000)}:R>`;
 }
 
-/**
- * Create Discord embed for regex matches
- */
-function createMatchesEmbed(pageName, url, patternResults) {
+function createMatchesPayload(pageName, url, patternResults) {
   const fields = [];
-  
   for (const [patternId, result] of Object.entries(patternResults)) {
-    const count = result.count;
     const uniqueStrings = result.matchedStrings || [];
-    
-    // Format matched strings as bullet points
-    let stringsValue = '';
-    if (uniqueStrings.length > 0) {
-      // Show up to 20 unique strings
-      const displayStrings = uniqueStrings.slice(0, 20);
-      stringsValue = displayStrings.map(s => `- \`${s}\``).join('\n');
-      
-      if (uniqueStrings.length > 20) {
-        stringsValue += `\n... and ${uniqueStrings.length - 20} more`;
-      }
-    } else {
-      stringsValue = '(no matches)';
-    }
+    const stringsValue = uniqueStrings.length > 0 
+      ? uniqueStrings.map(s => \`- \`\${s}\`\`).join('\n')
+      : '(no matches)';
 
-    // Discord field value limit is 1024. Truncate to 1000 for safety.
-    if (stringsValue.length > 1000) {
-        stringsValue = stringsValue.substring(0, 997) + '...';
+    const MAX_FIELD = 1000;
+    if (stringsValue.length > MAX_FIELD) {
+      const chunks = [];
+      let current = '';
+      for (const line of stringsValue.split('\n')) {
+        if (current.length + line.length > MAX_FIELD) {
+          chunks.push(current);
+          current = line + '\n';
+        } else {
+          current += line + '\n';
+        }
+      }
+      if (current) chunks.push(current);
+      
+      chunks.forEach((chunk, i) => {
+        fields.push({
+          name: \`Pattern: \${patternId} (part \${i+1})\`,
+          value: i === 0 ? \`**Count:** \${result.count}\n**Unique:** \${result.uniqueCount}\n\n\${chunk}\` : chunk
+        });
+      });
+    } else {
+      fields.push({
+        name: \`Pattern: \${patternId}\`,
+        value: \`**Count:** \${result.count}\n**Unique:** \${result.uniqueCount}\n\n\${stringsValue}\`
+      });
     }
-    
-    fields.push({
-      name: `Pattern: ${patternId.substring(0, 250)}`,
-      value: `**Count:** ${count}\n**Unique:** ${result.uniqueCount}\n\n${stringsValue}`
-    });
   }
   
   return {
@@ -435,160 +242,55 @@ function createMatchesEmbed(pageName, url, patternResults) {
     avatar_url: LOGO_URL,
     embeds: [{
       title: '🔍 Regex Match Detected',
-      description: `**${pageName}** ${getRelativeTimestamp()}`,
+      description: \`**\${pageName}** \${getRelativeTimestamp()}\`,
       url,
       color: 0x8B5CF6,
       fields,
       timestamp: new Date().toISOString(),
-      footer: {
-        text: 'Regex Watcher',
-        icon_url: LOGO_URL
-      }
+      footer: { text: 'Regex Watcher', icon_url: LOGO_URL }
     }]
   };
 }
 
-/**
- * Detect changes between current and previous state
- */
 function detectChanges(currentResults, previousState, url) {
-  const changes = {
-    hasChanges: false,
-    changes: []
-  };
-  
   const prevUrlState = previousState[url] || {};
   const prevPatterns = prevUrlState.patterns || {};
-  
+  const changes = { hasChanges: false, changes: [] };
   for (const [patternId, currentResult] of Object.entries(currentResults.patterns)) {
-    const prevResult = prevPatterns[patternId];
-    
     const currentCount = currentResult.count || 0;
-    const prevCount = prevResult?.count || 0;
-    
-    // Check for count changes (increase OR decrease)
+    const prevCount = prevPatterns[patternId]?.count || 0;
     if (currentCount !== prevCount) {
       changes.hasChanges = true;
-      changes.changes.push({
-        patternId,
-        previousCount: prevCount,
-        currentCount,
-        changeType: currentCount > prevCount ? 'increase' : 'decrease',
-        matchedStrings: currentResult.matchedStrings
-      });
+      changes.changes.push({ patternId, previousCount: prevCount, currentCount });
     }
   }
-  
   return changes;
 }
 
-/**
- * Main function
- */
 async function main() {
-  console.log('=== Regex Watcher ===');
-  console.log('Starting regex scan...');
-
   const config = loadConfig();
-  
-  // Validate URLs on startup
-  if (!validateUrls(config)) {
-    console.error('URL validation failed, exiting');
-    process.exit(1);
-  }
-  
-  console.log(`Validated ${config.pages?.length || 0} URL(s)`);
-
+  if (!validateUrls(config)) process.exit(1);
   const statePath = join(__dirname, '..', config.state?.file || 'logs/regex-state.json');
   const previousState = loadState(statePath);
-
   const webhookUrl = process.env[config.webhook?.webhookEnv];
+  if (!webhookUrl) process.exit(1);
 
-  if (!webhookUrl) {
-    console.error(`Webhook URL not configured (${config.webhook?.webhookEnv} env not set), exiting`);
-    process.exit(1);
-  }
-
-  const pages = config.pages || [];
-  const timeout = config.settings?.timeout || DEFAULT_TIMEOUT;
-  const delay = config.settings?.delay || DEFAULT_DELAY;
-  
-  console.log(`Watching ${pages.length} page(s)`);
-
-  let browser;
-  let hasChanges = false;
-
+  const browser = await launchBrowser(2);
+  const page = await browser.newPage();
   try {
-    // Launch browser with retry
-    browser = await launchBrowser(2);
-    const page = await browser.newPage();
-
-    for (let i = 0; i < pages.length; i++) {
-      const pageConfig = pages[i];
-      console.log(`Processing ${i + 1}/${pages.length}: ${pageConfig.name}`);
-      
-      try {
-        // Process URL and get results
-        const results = await processUrl(page, pageConfig.url, pageConfig.patterns, timeout);
-        
-        if (!results.success) {
-          console.log(`Failed to process ${pageConfig.name}: ${results.error}`);
-          continue;
-        }
-        
-        // Detect changes
-        const changes = detectChanges(results, previousState, pageConfig.url);
-        
-        if (changes.hasChanges) {
-          console.log(`Changes detected for ${pageConfig.name}:`);
-          for (const change of changes.changes) {
-            const emoji = change.changeType === 'increase' ? '📈' : '📉';
-            console.log(`  ${emoji} Pattern "${change.patternId}": ${change.previousCount} -> ${change.currentCount}`);
-          }
-          
-          // Send webhook notification
-          const embed = createMatchesEmbed(pageConfig.name, pageConfig.url, results.patterns);
-          await sendDiscordWebhook(webhookUrl, embed);
-          
-          hasChanges = true;
-        } else {
-          console.log(`No changes for ${pageConfig.name}`);
-        }
-        
-        // Update state
-        previousState[pageConfig.url] = {
-          patterns: results.patterns
-        };
-        
-      } catch (error) {
-        console.error(`Error processing ${pageConfig.name}:`, error.message);
-        // Continue with next URL
+    for (const pageConfig of config.pages) {
+      const results = await processUrl(page, pageConfig.url, pageConfig.patterns, config.settings?.timeout || DEFAULT_TIMEOUT);
+      if (!results.success) continue;
+      const changes = detectChanges(results, previousState, pageConfig.url);
+      if (changes.hasChanges) {
+        await sendDiscordWebhook(webhookUrl, createMatchesPayload(pageConfig.name, pageConfig.url, results.patterns));
       }
-      
-      // Delay between URLs (except for last)
-      if (i < pages.length - 1) {
-        console.log(`Waiting ${delay}ms before next URL...`);
-        await new Promise(resolve => setTimeout(resolve, delay));
-      }
+      previousState[pageConfig.url] = { patterns: results.patterns };
     }
-
-  } catch (error) {
-    console.error('Browser error:', error.message);
-    process.exit(1);
   } finally {
-    if (browser) {
-      await browser.close();
-    }
+    if (browser) await browser.close();
   }
-
-  // Save state
   saveState(statePath, previousState);
-
-  console.log(`=== Regex scan complete ===`);
 }
 
-// Run main function
-main().catch(err => {
-  console.error('Fatal error:', err);
-  process.exit(1);
-});
+main().catch(() => process.exit(1));

--- a/src/regex-watch.js
+++ b/src/regex-watch.js
@@ -373,9 +373,10 @@ async function sendDiscordWebhook(webhookUrl, payload) {
   }
 
   const { default: axios } = await import('axios');
+  const { safeEmbed } = await import('./webhook.js');
   
   try {
-    await axios.post(webhookUrl, payload, {
+    await axios.post(webhookUrl, safeEmbed(payload), {
       headers: { 'Content-Type': 'application/json' }
     });
     return true;
@@ -417,9 +418,14 @@ function createMatchesEmbed(pageName, url, patternResults) {
     } else {
       stringsValue = '(no matches)';
     }
+
+    // Discord field value limit is 1024. Truncate to 1000 for safety.
+    if (stringsValue.length > 1000) {
+        stringsValue = stringsValue.substring(0, 997) + '...';
+    }
     
     fields.push({
-      name: `Pattern: ${patternId}`,
+      name: `Pattern: ${patternId.substring(0, 250)}`,
       value: `**Count:** ${count}\n**Unique:** ${result.uniqueCount}\n\n${stringsValue}`
     });
   }

--- a/src/regex-watch.js
+++ b/src/regex-watch.js
@@ -225,13 +225,13 @@ function createMatchesPayload(pageName, url, patternResults) {
       
       chunks.forEach((chunk, i) => {
         fields.push({
-          name: \`Pattern: \${patternId} (part \${i+1})\`,
+          name: \`Pattern: \${patternId.substring(0, 247)} (part \${i+1})\`,
           value: i === 0 ? \`**Count:** \${result.count}\n**Unique:** \${result.uniqueCount}\n\n\${chunk}\` : chunk
         });
       });
     } else {
       fields.push({
-        name: \`Pattern: \${patternId}\`,
+        name: \`Pattern: \${patternId.substring(0, 247)}\`,
         value: \`**Count:** \${result.count}\n**Unique:** \${result.uniqueCount}\n\n\${stringsValue}\`
       });
     }

--- a/src/webhook.js
+++ b/src/webhook.js
@@ -130,11 +130,70 @@ export function chunkPayload(payload) {
 }
 
 /**
+ * Returns the total character count of a payload's embeds.
+ */
+function getPayloadCharCount(payload) {
+  if (!payload || !payload.embeds) return 0;
+  return payload.embeds.reduce((total, embed) => {
+    let count = (embed.title?.length || 0) + 
+                (embed.description?.length || 0) + 
+                (embed.footer?.text?.length || 0) + 
+                (embed.author?.name?.length || 0);
+    if (embed.fields) {
+      count += embed.fields.reduce((fTotal, f) => fTotal + (f.name?.length || 0) + (f.value?.length || 0), 0);
+    }
+    return total + count;
+  }, 0);
+}
+
+/**
  * Hard-truncate for legacy support, but now uses chunkPayload logic under the hood for send.
  */
 export function safeEmbed(payload) {
-  const chunks = chunkPayload(payload);
-  return chunks[0] || payload;
+  if (!payload) return payload;
+
+  // Deep clone to prevent side-effects
+  let clonedPayload;
+  try {
+    clonedPayload = JSON.parse(JSON.stringify(payload));
+  } catch (e) {
+    return payload; // Fallback to original if cloning fails
+  }
+
+  const chunks = chunkPayload(clonedPayload);
+  let firstChunk = chunks[0] || clonedPayload;
+
+  let totalChars = getPayloadCharCount(firstChunk);
+
+  // If still over the total limit, truncate descriptions first
+  if (totalChars > MAX_TOTAL_CHARS) {
+    for (const embed of firstChunk.embeds) {
+      if (totalChars <= MAX_TOTAL_CHARS) break;
+      if (embed.description) {
+        const oldLen = embed.description.length;
+        embed.description = truncate(embed.description, Math.max(100, embed.description.length - (totalChars - MAX_TOTAL_CHARS)));
+        totalChars -= (oldLen - embed.description.length);
+      }
+    }
+  }
+
+  // Robust fallback: truncate field values as a secondary measure
+  if (totalChars > MAX_TOTAL_CHARS && firstChunk.embeds) {
+    for (const embed of firstChunk.embeds) {
+      if (totalChars <= MAX_TOTAL_CHARS) break;
+      if (embed.fields) {
+        for (const field of embed.fields) {
+          if (totalChars <= MAX_TOTAL_CHARS) break;
+          const oldLen = field.value.length;
+          // Aggressively truncate fields to fit
+          field.value = truncate(field.value, Math.max(50, field.value.length - (totalChars - MAX_TOTAL_CHARS)));
+          totalChars -= (oldLen - field.value.length);
+        }
+      }
+    }
+  }
+
+  return firstChunk;
 }
 
 export async function sendDiscordWebhook(webhookUrl, payload) {

--- a/src/webhook.js
+++ b/src/webhook.js
@@ -7,6 +7,86 @@ const MAX_EMBEDS_PER_MESSAGE = 10;
 const MAX_MODELS_PER_EMBED = 50;
 
 /**
+ * Truncate a string safely to a specific length
+ * @param {string} str - String to truncate
+ * @param {number} maxLen - Maximum length
+ * @returns {string} - Truncated string
+ */
+export function truncate(str, maxLen) {
+  if (!str) return '';
+  if (str.length <= maxLen) return str;
+  return str.substring(0, maxLen - 3) + '...';
+}
+
+/**
+ * Hard-truncate the entire embed payload or individual fields so it doesn't exceed Discord limits.
+ * Discord limits:
+ * - Field name: 256 chars
+ * - Field value: 1024 chars
+ * - Description: 4096 chars
+ * - Title: 256 chars
+ * - Footer: 2048 chars
+ * - Total characters across all embeds in one message: 6000
+ */
+export function safeEmbed(payload) {
+  if (!payload || !payload.embeds) return payload;
+
+  let totalChars = 0;
+  const MAX_TOTAL_CHARS = 6000;
+
+  payload.embeds = payload.embeds.map(embed => {
+    // Title
+    if (embed.title) {
+      embed.title = truncate(embed.title, 256);
+      totalChars += embed.title.length;
+    }
+    // Description
+    if (embed.description) {
+      embed.description = truncate(embed.description, 4000);
+      totalChars += embed.description.length;
+    }
+    // Footer
+    if (embed.footer && embed.footer.text) {
+      embed.footer.text = truncate(embed.footer.text, 2048);
+      totalChars += embed.footer.text.length;
+    }
+    // Author
+    if (embed.author && embed.author.name) {
+      embed.author.name = truncate(embed.author.name, 256);
+      totalChars += embed.author.name.length;
+    }
+    // Fields
+    if (embed.fields) {
+      embed.fields = embed.fields.map(field => {
+        field.name = truncate(field.name, 256);
+        field.value = truncate(field.value, 1024);
+        totalChars += field.name.length + field.value.length;
+        return field;
+      });
+    }
+
+    return embed;
+  });
+
+  // If we're still over the total limit, we need to start removing or trimming description/fields
+  if (totalChars > MAX_TOTAL_CHARS) {
+    // Very basic strategy: if over 6000, truncate the first embed's description significantly
+    // or just hard truncate the whole structure stringified if we were desperate,
+    // but better to just cut fields/description.
+    for (const embed of payload.embeds) {
+      if (totalChars <= MAX_TOTAL_CHARS) break;
+      if (embed.description) {
+        const oldLen = embed.description.length;
+        embed.description = truncate(embed.description, Math.max(100, embed.description.length - (totalChars - MAX_TOTAL_CHARS)));
+        totalChars -= (oldLen - embed.description.length);
+      }
+    }
+  }
+
+  return payload;
+}
+
+/**
  * Send a Discord webhook notification
  * @param {string} webhookUrl - Discord webhook URL
  * @param {Object} payload - Embed payload
@@ -64,11 +144,11 @@ export async function sendDiscordWebhook(webhookUrl, payload) {
     // Send in chunks of MAX_EMBEDS_PER_MESSAGE
     for (let i = 0; i < allEmbeds.length; i += MAX_EMBEDS_PER_MESSAGE) {
       const chunk = allEmbeds.slice(i, i + MAX_EMBEDS_PER_MESSAGE);
-      const chunkPayload = {
+      const chunkPayload = safeEmbed({
         username: payload.username,
         avatar_url: payload.avatar_url,
         embeds: chunk
-      };
+      });
       await axios.post(webhookUrl, chunkPayload, {
         headers: { 'Content-Type': 'application/json' }
       });
@@ -284,10 +364,7 @@ export function createUpdatedModelsEmbed(endpointName, updates, commitSha = null
     }).join('\n');
     
     // Truncate if too long (Discord max field value is 1024)
-    let truncatedList = changeList;
-    if (changeList.length > 1000) {
-      truncatedList = changeList.substring(0, 997) + '...';
-    }
+    const truncatedList = truncate(changeList, 1000);
     
     const label = updates.length > maxPerField 
       ? `Updated Models (${i + 1}-${Math.min(i + maxPerField, updates.length)})`
@@ -333,7 +410,7 @@ export function createErrorEmbed(endpointName, error) {
       fields: [
         {
           name: 'Error Details',
-          value: `\`\`\`\n${error.substring(0, 500)}\n\`\`\``
+          value: `\`\`\`\n${truncate(error, 500)}\n\`\`\``
         }
       ],
       timestamp: new Date().toISOString(),
@@ -387,7 +464,7 @@ export function createSummaryEmbed(summary, results, commitSha = null) {
     ? `${baseUrl}/commit/${commitSha}`
     : `${baseUrl}/commits/master/logs/state.json`;
 
-  return {
+  return safeEmbed({
     username: 'Model Watcher',
     avatar_url: LOGO_URL,
     embeds: [{
@@ -408,7 +485,7 @@ export function createSummaryEmbed(summary, results, commitSha = null) {
         icon_url: LOGO_URL
       }
     }]
-  };
+  });
 }
 
 /**
@@ -425,7 +502,7 @@ export function createCompactSummaryEmbed(results) {
     return `${emoji} ${r.endpoint}: ${count}`;
   }).join('\n');
 
-  return {
+  return safeEmbed({
     username: 'Model Watcher',
     avatar_url: LOGO_URL,
     embeds: [{
@@ -435,7 +512,7 @@ export function createCompactSummaryEmbed(results) {
       fields: [
         {
           name: `Status (${successCount}/${results.length} online)`,
-          value: endpointStatus.substring(0, 1024)
+          value: truncate(endpointStatus, 1024)
         }
       ],
       timestamp: new Date().toISOString(),
@@ -444,7 +521,7 @@ export function createCompactSummaryEmbed(results) {
         icon_url: LOGO_URL
       }
     }]
-  };
+  });
 }
 
 /**
@@ -602,11 +679,11 @@ export async function sendRawDiffWebhook(webhookUrl, payload) {
     // Send in chunks of MAX_EMBEDS_PER_MESSAGE
     for (let i = 0; i < embeds.length; i += MAX_EMBEDS_PER_MESSAGE) {
       const chunk = embeds.slice(i, i + MAX_EMBEDS_PER_MESSAGE);
-      const chunkPayload = {
+      const chunkPayload = safeEmbed({
         username: payload.username,
         avatar_url: payload.avatar_url,
         embeds: chunk
-      };
+      });
       await axios.post(webhookUrl, chunkPayload, {
         headers: { 'Content-Type': 'application/json' }
       });
@@ -682,13 +759,13 @@ export function createAppVersionEmbed(appInfo) {
   const description = htmlToMarkdown(rawDescription);
   const releaseNotes = htmlToMarkdown(rawReleaseNotes);
 
-  return {
+  return safeEmbed({
     username: 'App Version Watcher',
     avatar_url: LOGO_URL,
     embeds: [{
       title: `${platformEmoji} ${appInfo.title} — v${appInfo.version}`,
       url: appInfo.url,
-      description: description.length > 300 ? description.substring(0, 297) + '...' : description,
+      description: truncate(description, 300),
       color,
       thumbnail: {
         url: appInfo.icon
@@ -696,16 +773,16 @@ export function createAppVersionEmbed(appInfo) {
       fields: [
         {
           name: '📝 Release Notes',
-          value: releaseNotes.substring(0, 1024) || '(none)'
+          value: truncate(releaseNotes, 1000) || '(none)'
         },
         {
           name: '🏢 Developer',
-          value: appInfo.developer || 'Unknown',
+          value: truncate(appInfo.developer || 'Unknown', 100),
           inline: true
         },
         {
           name: '📦 App ID',
-          value: `\`${appInfo.appId}\``,
+          value: `\`${truncate(appInfo.appId, 100)}\``,
           inline: true
         },
         {
@@ -720,7 +797,7 @@ export function createAppVersionEmbed(appInfo) {
         icon_url: LOGO_URL
       }
     }]
-  };
+  });
 }
 
 /**
@@ -1147,12 +1224,12 @@ export function createLMArenaEmbed(diff, totalModels) {
     }
   }
 
-  // No truncation — sendDiscordWebhook batches into multiple API calls
-  return {
+  // Hard-truncate the entire payload to 6000
+  return safeEmbed({
     username: 'LM Arena Watcher',
     avatar_url: LOGO_URL,
     embeds,
-  };
+  });
 }
 
 export function createStringsDiffEmbed(appId, diffText) {
@@ -1223,9 +1300,9 @@ export function createStringsDiffEmbed(appId, diffText) {
     embeds.push(embed);
   }
 
-  return {
+  return safeEmbed({
     username: 'Android Strings Watcher',
     avatar_url: LOGO_URL,
     embeds
-  };
+  });
 }

--- a/src/webhook.js
+++ b/src/webhook.js
@@ -4,7 +4,12 @@ import axios from 'axios';
 const LOGO_URL = 'https://raw.githubusercontent.com/CloudWaddie/ModelWatcher/master/logo.jpg';
 
 const MAX_EMBEDS_PER_MESSAGE = 10;
-const MAX_MODELS_PER_EMBED = 50;
+const MAX_TOTAL_CHARS = 6000;
+const MAX_DESCRIPTION = 4000;
+const MAX_FIELD_NAME = 256;
+const MAX_FIELD_VALUE = 1024;
+const MAX_TITLE = 256;
+const MAX_FOOTER = 2048;
 
 /**
  * Truncate a string safely to a specific length
@@ -19,1290 +24,214 @@ export function truncate(str, maxLen) {
 }
 
 /**
- * Hard-truncate the entire embed payload or individual fields so it doesn't exceed Discord limits.
- * Discord limits:
- * - Field name: 256 chars
- * - Field value: 1024 chars
- * - Description: 4096 chars
- * - Title: 256 chars
- * - Footer: 2048 chars
- * - Total characters across all embeds in one message: 6000
+ * Splits fields into multiple embeds if they exceed limits.
+ * @param {Array} fields - Array of field objects
+ * @returns {Array<Array>} - Array of field chunks (max 25 per chunk)
+ */
+function chunkFields(fields) {
+  if (!fields) return [];
+  const chunks = [];
+  for (let i = 0; i < fields.length; i += 25) {
+    chunks.push(fields.slice(i, i + 25));
+  }
+  return chunks;
+}
+
+/**
+ * Ensures an embed stays within Discord limits by returning an array of embeds if necessary.
+ */
+function splitEmbed(embed) {
+  const embeds = [];
+  
+  // Truncate non-field properties
+  const baseEmbed = { ...embed };
+  if (baseEmbed.title) baseEmbed.title = truncate(baseEmbed.title, MAX_TITLE);
+  if (baseEmbed.description) baseEmbed.description = truncate(baseEmbed.description, MAX_DESCRIPTION);
+  if (baseEmbed.footer?.text) baseEmbed.footer.text = truncate(baseEmbed.footer.text, MAX_FOOTER);
+  if (baseEmbed.author?.name) baseEmbed.author.name = truncate(baseEmbed.author.name, MAX_TITLE);
+
+  const fieldChunks = chunkFields(embed.fields);
+  
+  if (fieldChunks.length === 0) {
+    embeds.push(baseEmbed);
+    return embeds;
+  }
+
+  for (let i = 0; i < fieldChunks.length; i++) {
+    const chunk = fieldChunks[i].map(f => ({
+      name: truncate(f.name, MAX_FIELD_NAME),
+      value: truncate(f.value, MAX_FIELD_VALUE),
+      inline: f.inline
+    }));
+
+    const newEmbed = { 
+      ...baseEmbed, 
+      fields: chunk 
+    };
+
+    // Only keep title/description/author on the first embed of a split
+    if (i > 0) {
+      delete newEmbed.title;
+      delete newEmbed.description;
+      delete newEmbed.author;
+      delete newEmbed.thumbnail;
+      if (baseEmbed.title) newEmbed.title = `${baseEmbed.title} (cont. ${i + 1})`;
+    }
+    
+    embeds.push(newEmbed);
+  }
+
+  return embeds;
+}
+
+/**
+ * Processes a payload and returns an array of payloads, each within Discord message limits.
+ */
+export function chunkPayload(payload) {
+  const allEmbeds = [];
+  if (payload.embeds) {
+    for (const embed of payload.embeds) {
+      allEmbeds.push(...splitEmbed(embed));
+    }
+  }
+
+  const payloads = [];
+  let currentEmbeds = [];
+  let currentTotalChars = 0;
+
+  for (const embed of allEmbeds) {
+    const embedChars = (embed.title?.length || 0) + 
+                       (embed.description?.length || 0) + 
+                       (embed.footer?.text?.length || 0) + 
+                       (embed.author?.name?.length || 0) + 
+                       (embed.fields?.reduce((acc, f) => acc + f.name.length + f.value.length, 0) || 0);
+
+    if ((currentEmbeds.length >= MAX_EMBEDS_PER_MESSAGE || currentTotalChars + embedChars > MAX_TOTAL_CHARS) && currentEmbeds.length > 0) {
+      payloads.push({
+        ...payload,
+        embeds: currentEmbeds
+      });
+      currentEmbeds = [];
+      currentTotalChars = 0;
+    }
+
+    currentEmbeds.push(embed);
+    currentTotalChars += embedChars;
+  }
+
+  if (currentEmbeds.length > 0) {
+    payloads.push({
+      ...payload,
+      embeds: currentEmbeds
+    });
+  }
+
+  return payloads;
+}
+
+/**
+ * Hard-truncate for legacy support, but now uses chunkPayload logic under the hood for send.
  */
 export function safeEmbed(payload) {
-  if (!payload || !payload.embeds) return payload;
-
-  let totalChars = 0;
-  const MAX_TOTAL_CHARS = 6000;
-
-  payload.embeds = payload.embeds.map(embed => {
-    // Title
-    if (embed.title) {
-      embed.title = truncate(embed.title, 256);
-      totalChars += embed.title.length;
-    }
-    // Description
-    if (embed.description) {
-      embed.description = truncate(embed.description, 4000);
-      totalChars += embed.description.length;
-    }
-    // Footer
-    if (embed.footer && embed.footer.text) {
-      embed.footer.text = truncate(embed.footer.text, 2048);
-      totalChars += embed.footer.text.length;
-    }
-    // Author
-    if (embed.author && embed.author.name) {
-      embed.author.name = truncate(embed.author.name, 256);
-      totalChars += embed.author.name.length;
-    }
-    // Fields
-    if (embed.fields) {
-      embed.fields = embed.fields.map(field => {
-        field.name = truncate(field.name, 256);
-        field.value = truncate(field.value, 1024);
-        totalChars += field.name.length + field.value.length;
-        return field;
-      });
-    }
-
-    return embed;
-  });
-
-  // If we're still over the total limit, we need to start removing or trimming description/fields
-  if (totalChars > MAX_TOTAL_CHARS) {
-    // Very basic strategy: if over 6000, truncate the first embed's description significantly
-    // or just hard truncate the whole structure stringified if we were desperate,
-    // but better to just cut fields/description.
-    for (const embed of payload.embeds) {
-      if (totalChars <= MAX_TOTAL_CHARS) break;
-      if (embed.description) {
-        const oldLen = embed.description.length;
-        embed.description = truncate(embed.description, Math.max(100, embed.description.length - (totalChars - MAX_TOTAL_CHARS)));
-        totalChars -= (oldLen - embed.description.length);
-      }
-    }
-  }
-
-  return payload;
+  const chunks = chunkPayload(payload);
+  return chunks[0] || payload;
 }
 
-/**
- * Send a Discord webhook notification
- * @param {string} webhookUrl - Discord webhook URL
- * @param {Object} payload - Embed payload
- * @returns {Promise<boolean>} - Success status
- */
 export async function sendDiscordWebhook(webhookUrl, payload) {
-  if (!webhookUrl) {
-    console.log('Discord webhook URL not configured, skipping notification');
-    return false;
-  }
-
+  if (!webhookUrl) return false;
   try {
-    const embeds = payload.embeds || [];
-    const allEmbeds = [];
-
-    // Split embeds that have too many models into multiple embeds
-    for (const embed of embeds) {
-      if (embed.fields && embed.fields.length > 0) {
-        // Count total models across all fields
-        let totalModels = 0;
-        for (const field of embed.fields) {
-          const lines = field.value.split('\n').filter(l => l.trim());
-          totalModels += lines.length;
-        }
-
-        if (totalModels > MAX_MODELS_PER_EMBED) {
-          // Split into multiple embeds
-          let currentEmbed = { ...embed, fields: [] };
-          let currentCount = 0;
-
-          for (const field of embed.fields) {
-            const fieldCount = field.value.split('\n').filter(l => l.trim()).length;
-
-            if (currentCount + fieldCount > MAX_MODELS_PER_EMBED && currentEmbed.fields.length > 0) {
-              allEmbeds.push(currentEmbed);
-              currentEmbed = { ...embed, fields: [] };
-              currentCount = 0;
-            }
-
-            currentEmbed.fields.push(field);
-            currentCount += fieldCount;
-          }
-
-          if (currentEmbed.fields.length > 0) {
-            allEmbeds.push(currentEmbed);
-          }
-        } else {
-          allEmbeds.push(embed);
-        }
-      } else {
-        allEmbeds.push(embed);
-      }
+    const payloads = chunkPayload(payload);
+    for (const p of payloads) {
+      await axios.post(webhookUrl, p, { headers: { 'Content-Type': 'application/json' } });
     }
-
-    // Send in chunks of MAX_EMBEDS_PER_MESSAGE
-    for (let i = 0; i < allEmbeds.length; i += MAX_EMBEDS_PER_MESSAGE) {
-      const chunk = allEmbeds.slice(i, i + MAX_EMBEDS_PER_MESSAGE);
-      const chunkPayload = safeEmbed({
-        username: payload.username,
-        avatar_url: payload.avatar_url,
-        embeds: chunk
-      });
-      await axios.post(webhookUrl, chunkPayload, {
-        headers: { 'Content-Type': 'application/json' }
-      });
-    }
-
     return true;
   } catch (err) {
-    const details = err.response?.data ? JSON.stringify(err.response.data) : err.message;
-    console.error('Failed to send Discord webhook:', err.response?.status, details);
+    console.error('Failed to send Discord webhook:', err.response?.status, err.message);
     return false;
   }
 }
 
-/**
- * Get Discord relative timestamp string
- * @returns {string} - Discord timestamp format
- */
 function getRelativeTimestamp() {
   const unixSeconds = Math.floor(Date.now() / 1000);
   return `<t:${unixSeconds}:R>`;
 }
 
-/**
- * Create a nicely formatted Discord embed for new models
- * @param {string} endpointName - Name of the endpoint
- * @param {Array} models - Array of new models
- * @returns {Object} - Discord embed object
- */
-export function createNewModelsEmbed(endpointName, models) {
-  const maxPerField = 10;
-  const maxTotal = 20;
+export function createSummaryEmbed(summary, results, commitSha = null) {
+  const successCount = results.filter(r => r.success).length;
+  const failCount = results.filter(r => !r.success).length;
+  
   const fields = [];
-  
-  // If too many models, just show count
-  if (models.length > maxTotal) {
-    return {
-      username: 'Model Watcher',
-      avatar_url: LOGO_URL,
-      embeds: [{
-        title: '🆕 New Models Detected',
-        description: `**${endpointName}** added **${models.length}** new models ${getRelativeTimestamp()}!\n\nFull list: [logs/state.json](https://github.com/CloudWaddie/ModelWatcher/blob/master/logs/state.json)`,
-        color: 0x10B981,
-        timestamp: new Date().toISOString(),
-        footer: {
-          text: 'Model Watcher • AI Model Scanner',
-          icon_url: LOGO_URL
-        }
-      }]
-    };
-  }
-  
-  for (let i = 0; i < models.length; i += maxPerField) {
-    const chunk = models.slice(i, i + maxPerField);
-    const modelList = chunk.map(m => m.id).join('\n');
-    const label = models.length > maxPerField 
-      ? `New Models (${i + 1}-${Math.min(i + maxPerField, models.length)})`
-      : 'New Models';
-    
+  fields.push({
+    name: 'Changes This Scan',
+    value: `➕ **${summary.addedCount}** added | ➖ **${summary.removedCount}** removed | 🔄 **${summary.updatedCount}** updated`,
+    inline: false
+  });
+
+  for (const result of results) {
+    const emoji = result.success ? '🟢' : '🔴';
+    const count = result.success ? `${result.models.length} models` : 'Failed';
     fields.push({
-      name: label,
-      value: '```\n' + modelList + '\n```'
+      name: result.endpoint,
+      value: `${emoji} ${count}`,
+      inline: true
     });
   }
+  
+  const baseUrl = 'https://github.com/CloudWaddie/ModelWatcher';
+  const diffUrl = commitSha ? `${baseUrl}/commit/${commitSha}` : `${baseUrl}/commits/master/logs/state.json`;
+
+  return {
+    username: 'Model Watcher',
+    avatar_url: LOGO_URL,
+    embeds: [{
+      title: '🔍 Model Scan Complete',
+      description: `Scanned **${results.length}** endpoints | ${successCount} success, ${failCount} failed ${getRelativeTimestamp()}\n\nView changes: [GitHub Diff](${diffUrl})`,
+      color: summary.removedCount > 0 ? 0xEF4444 : (summary.addedCount > 0 ? 0x10B981 : 0x3B82F6),
+      fields,
+      timestamp: new Date().toISOString(),
+      footer: { text: 'Model Watcher • Hourly Scan', icon_url: LOGO_URL }
+    }]
+  };
+}
+
+export function createNewModelsEmbed(endpointName, models) {
+  const fields = models.map(m => ({
+    name: 'New Model',
+    value: \`\${m.id}\`,
+    inline: true
+  }));
 
   return {
     username: 'Model Watcher',
     avatar_url: LOGO_URL,
     embeds: [{
       title: '🆕 New Models Detected',
-      description: `**${endpointName}** just added ${models.length} new model${models.length > 1 ? 's' : ''} ${getRelativeTimestamp()}!`,
+      description: \`**\${endpointName}** just added \${models.length} new model\${models.length > 1 ? 's' : ''} \${getRelativeTimestamp()}!\`,
       color: 0x10B981,
       fields,
       timestamp: new Date().toISOString(),
-      footer: {
-        text: 'Model Watcher • AI Model Scanner',
-        icon_url: LOGO_URL
-      }
+      footer: { text: 'Model Watcher • AI Model Scanner', icon_url: LOGO_URL }
     }]
   };
 }
 
-/**
- * Create Discord embed for removed models
- * @param {string} endpointName - Name of the endpoint
- * @param {Array} models - Array of removed models
- * @returns {Object} - Discord embed object
- */
 export function createRemovedModelsEmbed(endpointName, models) {
-  const maxPerField = 10;
-  const maxTotal = 20;
-  const fields = [];
-  
-  if (models.length > maxTotal) {
-    return {
-      username: 'Model Watcher',
-      avatar_url: LOGO_URL,
-      embeds: [{
-        title: '🗑️ Models Removed',
-        description: `**${endpointName}** removed **${models.length}** models ${getRelativeTimestamp()}.\n\nFull list: [logs/state.json](https://github.com/CloudWaddie/ModelWatcher/blob/master/logs/state.json)`,
-        color: 0xEF4444,
-        timestamp: new Date().toISOString(),
-        footer: {
-          text: 'Model Watcher • AI Model Scanner',
-          icon_url: LOGO_URL
-        }
-      }]
-    };
-  }
-  
-  for (let i = 0; i < models.length; i += maxPerField) {
-    const chunk = models.slice(i, i + maxPerField);
-    const modelList = chunk.map(m => m.id).join('\n');
-    const label = models.length > maxPerField 
-      ? `Removed Models (${i + 1}-${Math.min(i + maxPerField, models.length)})`
-      : 'Removed Models';
-    
-    fields.push({
-      name: label,
-      value: '```\n' + modelList + '\n```'
-    });
-  }
+  const fields = models.map(m => ({
+    name: 'Removed Model',
+    value: \`\${m.id}\`,
+    inline: true
+  }));
 
   return {
     username: 'Model Watcher',
     avatar_url: LOGO_URL,
     embeds: [{
       title: '🗑️ Models Removed',
-      description: `**${endpointName}** removed ${models.length} model${models.length > 1 ? 's' : ''} ${getRelativeTimestamp()}.`,
+      description: \`**\${endpointName}** removed \${models.length} model\${models.length > 1 ? 's' : ''} \${getRelativeTimestamp()}.\`,
       color: 0xEF4444,
       fields,
       timestamp: new Date().toISOString(),
-      footer: {
-        text: 'Model Watcher • AI Model Scanner',
-        icon_url: LOGO_URL
-      }
+      footer: { text: 'Model Watcher • AI Model Scanner', icon_url: LOGO_URL }
     }]
   };
-}
-
-/**
- * Format a value for display in diff
- * Escapes backticks to prevent breaking Discord code blocks
- */
-function formatValue(val) {
-  if (val === null || val === undefined) return '(none)';
-  if (Array.isArray(val)) return val.join(', ');
-  if (typeof val === 'object') return JSON.stringify(val);
-  return String(val);
-}
-
-/**
- * Escape backticks in a string for use in Discord code blocks
- * @param {string} str - String to escape
- * @returns {string} - Escaped string
- */
-function escapeBackticks(str) {
-  return str.replace(/`/g, '`\u200b');
-}
-
-/**
- * Format a single change as a git diff style string
- * @param {string} key - Property name that changed
- * @param {Object} change - Object with old and new values
- * @returns {string} - Formatted diff string
- */
-function formatDiffLine(key, change) {
-  const oldVal = escapeBackticks(formatValue(change.old));
-  const newVal = escapeBackticks(formatValue(change.new));
-  return `-${key}: ${oldVal}\n+${key}: ${newVal}`;
-}
-
-/**
- * Create Discord embed for updated models
- * @param {string} endpointName - Name of the endpoint
- * @param {Array} updates - Array of updated models with changes
- * @param {string} commitSha - Optional commit SHA for direct link
- * @returns {Object} - Discord embed object
- */
-export function createUpdatedModelsEmbed(endpointName, updates, commitSha = null) {
-  const maxPerField = 10;
-  const maxTotal = 20;
-  const fields = [];
-  
-  const baseUrl = 'https://github.com/CloudWaddie/ModelWatcher';
-  const diffUrl = commitSha 
-    ? `${baseUrl}/commit/${commitSha}`
-    : `${baseUrl}/commits/master/logs/state.json`;
-  
-  if (updates.length > maxTotal) {
-    return {
-      username: 'Model Watcher',
-      avatar_url: LOGO_URL,
-      embeds: [{
-        title: '🔄 Models Updated',
-        description: `**${endpointName}** has **${updates.length}** model updates ${getRelativeTimestamp()}.\n\nView changes: [GitHub Diff](${diffUrl})`,
-        color: 0xF59E0B,
-        timestamp: new Date().toISOString(),
-        footer: {
-          text: 'Model Watcher • AI Model Scanner',
-          icon_url: LOGO_URL
-        }
-      }]
-    };
-  }
-  
-  for (let i = 0; i < updates.length; i += maxPerField) {
-    const chunk = updates.slice(i, i + maxPerField);
-    const changeList = chunk.map(u => {
-      const changeLines = Object.entries(u.changes).map(([key, change]) => {
-        return formatDiffLine(key, change);
-      }).join('\n');
-      return `**${u.model.id}**\n\`\`\`\n${changeLines}\n\`\`\``;
-    }).join('\n');
-    
-    // Truncate if too long (Discord max field value is 1024)
-    const truncatedList = truncate(changeList, 1000);
-    
-    const label = updates.length > maxPerField 
-      ? `Updated Models (${i + 1}-${Math.min(i + maxPerField, updates.length)})`
-      : 'Updated Models';
-    
-    fields.push({
-      name: label,
-      value: truncatedList
-    });
-  }
-
-  return {
-    username: 'Model Watcher',
-    avatar_url: LOGO_URL,
-    embeds: [{
-      title: '🔄 Models Updated',
-      description: `**${endpointName}** has ${updates.length} model update${updates.length > 1 ? 's' : ''} ${getRelativeTimestamp()}.\n\nView changes: [GitHub Diff](${diffUrl})`,
-      color: 0xF59E0B,
-      fields,
-      timestamp: new Date().toISOString(),
-      footer: {
-        text: 'Model Watcher • AI Model Scanner',
-        icon_url: LOGO_URL
-      }
-    }]
-  };
-}
-
-/**
- * Create Discord embed for endpoint errors
- * @param {string} endpointName - Name of the endpoint
- * @param {string} error - Error message
- * @returns {Object} - Discord embed object
- */
-export function createErrorEmbed(endpointName, error) {
-  return {
-    username: 'Model Watcher',
-    avatar_url: LOGO_URL,
-    embeds: [{
-      title: '⚠️ Endpoint Error',
-      description: `Failed to fetch models from **${endpointName}** ${getRelativeTimestamp()}`,
-      color: 0xF97316,
-      fields: [
-        {
-          name: 'Error Details',
-          value: `\`\`\`\n${truncate(error, 500)}\n\`\`\``
-        }
-      ],
-      timestamp: new Date().toISOString(),
-      footer: {
-        text: 'Model Watcher • AI Model Scanner',
-        icon_url: LOGO_URL
-      }
-    }]
-  };
-}
-
-/**
- * Create a summary embed for scan results with changes
- * @param {Object} summary - Scan summary
- * @param {Array} results - Endpoint results
- * @param {string} commitSha - Optional commit SHA for direct link
- * @returns {Object} - Discord embed object
- */
-export function createSummaryEmbed(summary, results, commitSha = null) {
-  const successCount = results.filter(r => r.success).length;
-  const failCount = results.filter(r => !r.success).length;
-  
-  const endpointFields = [];
-  let currentField = { name: 'Endpoints', value: '' };
-  
-  for (const result of results) {
-    const emoji = result.success ? '🟢' : '🔴';
-    const count = result.success ? `${result.models.length} models` : 'Failed';
-    const line = `${emoji} **${result.endpoint}**: ${count}`;
-    
-    if (currentField.value.length + line.length > 1000) {
-      endpointFields.push(currentField);
-      currentField = { name: 'Endpoints (cont.)', value: '' };
-    }
-    
-    currentField.value += line + '\n';
-  }
-  
-  endpointFields.push(currentField);
-
-  let color = 0x3B82F6;
-  if (summary.addedCount > 0 && summary.removedCount === 0) {
-    color = 0x10B981;
-  } else if (summary.removedCount > 0) {
-    color = 0xEF4444;
-  }
-
-  const changeEmoji = summary.addedCount > 0 ? '📈' : summary.removedCount > 0 ? '📉' : '➡️';
-  const baseUrl = 'https://github.com/CloudWaddie/ModelWatcher';
-  const diffUrl = commitSha 
-    ? `${baseUrl}/commit/${commitSha}`
-    : `${baseUrl}/commits/master/logs/state.json`;
-
-  return safeEmbed({
-    username: 'Model Watcher',
-    avatar_url: LOGO_URL,
-    embeds: [{
-      title: '🔍 Model Scan Complete',
-      description: `${changeEmoji} Scanned **${results.length}** endpoints | ${successCount} success, ${failCount} failed ${getRelativeTimestamp()}\n\nView changes: [GitHub Diff](${diffUrl})`,
-      color,
-      fields: [
-        {
-          name: 'Changes This Scan',
-          value: `➕ **${summary.addedCount}** added | ➖ **${summary.removedCount}** removed | 🔄 **${summary.updatedCount}** updated`,
-          inline: false
-        },
-        ...endpointFields
-      ],
-      timestamp: new Date().toISOString(),
-      footer: {
-        text: 'Model Watcher • Hourly Scan',
-        icon_url: LOGO_URL
-      }
-    }]
-  });
-}
-
-/**
- * Create a compact summary embed (for when there are no changes)
- * @param {Array} results - Endpoint results
- * @returns {Object} - Discord embed object
- */
-export function createCompactSummaryEmbed(results) {
-  const successCount = results.filter(r => r.success).length;
-  
-  const endpointStatus = results.map(r => {
-    const emoji = r.success ? '✅' : '❌';
-    const count = r.success ? r.models.length : 0;
-    return `${emoji} ${r.endpoint}: ${count}`;
-  }).join('\n');
-
-  return safeEmbed({
-    username: 'Model Watcher',
-    avatar_url: LOGO_URL,
-    embeds: [{
-      title: '✅ No Model Changes',
-      description: `Scanned **${results.length}** endpoints - no changes detected ${getRelativeTimestamp()}`,
-      color: 0x6B7280,
-      fields: [
-        {
-          name: `Status (${successCount}/${results.length} online)`,
-          value: truncate(endpointStatus, 1024)
-        }
-      ],
-      timestamp: new Date().toISOString(),
-      footer: {
-        text: 'Model Watcher • Hourly Scan',
-        icon_url: LOGO_URL
-      }
-    }]
-  });
-}
-
-/**
- * Process scan results and send appropriate Discord notifications
- * @param {Object} config - Discord configuration
- * @param {Array} results - Scan results from all endpoints
- * @param {Object} allChanges - Changes detected across all endpoints
- * @param {Array} endpoints - Endpoint configurations (to get group mapping)
- * @param {string} commitSha - Optional commit SHA for direct link
- * @returns {Promise<void>}
- */
-export async function processNotifications(config, results, allChanges, endpoints, commitSha = null) {
-  if (!config.enabled) {
-    console.log('Discord notifications disabled');
-    return;
-  }
-
-  const webhooks = config.webhooks || {};
-  const embedUrl = config.url || null;
-
-  // Build endpoint -> group mapping
-  const endpointGroups = {};
-  for (const ep of endpoints) {
-    endpointGroups[ep.name] = ep.group || 'default';
-  }
-
-  // Group changes by webhook group
-  const groupChanges = {};
-  const groupResults = {};
-  
-  for (const [endpointName, changes] of Object.entries(allChanges)) {
-    const group = endpointGroups[endpointName] || 'default';
-    if (!groupChanges[group]) {
-      groupChanges[group] = {};
-      groupResults[group] = [];
-    }
-    groupChanges[group][endpointName] = changes;
-  }
-  
-  for (const result of results) {
-    const group = endpointGroups[result.endpoint] || 'default';
-    if (!groupResults[group]) {
-      groupResults[group] = [];
-    }
-    groupResults[group].push(result);
-  }
-
-  // Process each group
-  for (const [groupName, groupConfig] of Object.entries(webhooks)) {
-    const webhookUrl = process.env[groupConfig.webhookEnv];
-    const notifyOn = groupConfig.notifyOn || [];
-    
-    if (!webhookUrl) {
-      console.log(`Discord webhook for group "${groupName}" not set (${groupConfig.webhookEnv} env), skipping`);
-      continue;
-    }
-
-    const groupChangesList = groupChanges[groupName] || {};
-    const groupResultsList = groupResults[groupName] || [];
-    
-    // Skip if no results for this group
-    if (groupResultsList.length === 0) {
-      continue;
-    }
-
-    let totalAdded = 0;
-    let totalRemoved = 0;
-    let totalUpdated = 0;
-    
-    for (const changes of Object.values(groupChangesList)) {
-      if (changes.summary) {
-        totalAdded += changes.summary.addedCount;
-        totalRemoved += changes.summary.removedCount;
-        totalUpdated += changes.summary.updatedCount;
-      }
-    }
-
-    const hasChanges = totalAdded > 0 || totalRemoved > 0 || totalUpdated > 0;
-
-    const summary = {
-      addedCount: totalAdded,
-      removedCount: totalRemoved,
-      updatedCount: totalUpdated
-    };
-
-    // Helper to add URL to embed
-    const withUrl = (payload) => {
-      if (embedUrl && payload.embeds?.[0]) {
-        payload.embeds[0].url = embedUrl;
-      }
-      return payload;
-    };
-
-    // Send summary only if there are changes
-    if (hasChanges && notifyOn.includes('summary_with_changes')) {
-      await sendDiscordWebhook(webhookUrl, withUrl(createSummaryEmbed(summary, groupResultsList, commitSha)));
-    }
-
-    // Send endpoint errors (skip if API key not configured)
-    if (notifyOn.includes('endpoint_error')) {
-      for (const result of groupResultsList) {
-        if (!result.success && result.error && result.configured === false) {
-          continue;
-        }
-        if (!result.success && result.error) {
-          await sendDiscordWebhook(webhookUrl, withUrl(createErrorEmbed(result.endpoint, result.error)));
-        }
-      }
-    }
-
-    // Send new models notifications
-    if (notifyOn.includes('new_model')) {
-      for (const [endpoint, changes] of Object.entries(groupChangesList)) {
-        if (changes.added && changes.added.length > 0) {
-          await sendDiscordWebhook(webhookUrl, withUrl(createNewModelsEmbed(endpoint, changes.added)));
-        }
-      }
-    }
-
-    // Send removed models notifications
-    if (notifyOn.includes('removed_model')) {
-      for (const [endpoint, changes] of Object.entries(groupChangesList)) {
-        if (changes.removed && changes.removed.length > 0) {
-          await sendDiscordWebhook(webhookUrl, withUrl(createRemovedModelsEmbed(endpoint, changes.removed)));
-        }
-      }
-    }
-
-    // Send updated models notifications
-    if (notifyOn.includes('model_updated')) {
-      for (const [endpoint, changes] of Object.entries(groupChangesList)) {
-        if (changes.updated && changes.updated.length > 0) {
-          await sendDiscordWebhook(webhookUrl, withUrl(createUpdatedModelsEmbed(endpoint, changes.updated, commitSha)));
-        }
-      }
-    }
-  }
-}
-
-/**
- * Send a Discord webhook without model-splitting logic (for raw diffs)
- * @param {string} webhookUrl - Discord webhook URL
- * @param {Object} payload - Embed payload
- * @returns {Promise<boolean>} - Success status
- */
-export async function sendRawDiffWebhook(webhookUrl, payload) {
-  if (!webhookUrl) {
-    console.log('Discord webhook URL not configured, skipping notification');
-    return false;
-  }
-
-  try {
-    const embeds = payload.embeds || [];
-
-    // Send in chunks of MAX_EMBEDS_PER_MESSAGE
-    for (let i = 0; i < embeds.length; i += MAX_EMBEDS_PER_MESSAGE) {
-      const chunk = embeds.slice(i, i + MAX_EMBEDS_PER_MESSAGE);
-      const chunkPayload = safeEmbed({
-        username: payload.username,
-        avatar_url: payload.avatar_url,
-        embeds: chunk
-      });
-      await axios.post(webhookUrl, chunkPayload, {
-        headers: { 'Content-Type': 'application/json' }
-      });
-    }
-
-    return true;
-  } catch (err) {
-    const details = err.response?.data ? JSON.stringify(err.response.data) : err.message;
-    console.error('Failed to send Discord webhook:', err.response?.status, details);
-    return false;
-  }
-}
-
-/**
- * Convert simple HTML to Discord-compatible markdown
- */
-function htmlToMarkdown(html) {
-  if (!html) return html;
-  return html
-    // Line breaks
-    .replace(/<br\s*\/?>\n?/gi, '\n')
-    .replace(/<\/p>\s*/gi, '\n\n')
-    .replace(/<p>\s*/gi, '')
-    // Lists
-    .replace(/<ul>\n?/gi, '')
-    .replace(/<\/ul>\n?/gi, '')
-    .replace(/<ol>\n?/gi, '')
-    .replace(/<\/ol>\n?/gi, '')
-    .replace(/<li>\n?/gi, '• ')
-    .replace(/<\/li>\n?/gi, '\n')
-    // Inline formatting
-    .replace(/<strong>/gi, '**')
-    .replace(/<\/strong>/gi, '**')
-    .replace(/<b>/gi, '**')
-    .replace(/<\/b>/gi, '**')
-    .replace(/<i>/gi, '*')
-    .replace(/<\/i>/gi, '*')
-    .replace(/<em>/gi, '*')
-    .replace(/<\/em>/gi, '*')
-    .replace(/<code>/gi, '`')
-    .replace(/<\/code>/gi, '`')
-    // Links
-    .replace(/<a\s+[^>]*href="([^"]*)"[^>]*>/gi, '[$1]($1)')
-    .replace(/<\/a>/gi, '')
-    // Strip remaining tags
-    .replace(/<[^>]*>/g, '')
-    // HTML entities
-    .replace(/&amp;/g, '&')
-    .replace(/&lt;/g, '<')
-    .replace(/&gt;/g, '>')
-    .replace(/&quot;/g, '"')
-    .replace(/&#39;/g, "'")
-    .replace(/&nbsp;/g, ' ')
-    // Collapse multiple newlines to max 2
-    .replace(/\n{3,}/g, '\n\n')
-    // Trim each line
-    .split('\n').map(l => l.trim()).join('\n')
-    .trim();
-}
-
-/**
- * Create a nice Discord embed for a new app version
- * @param {Object} appInfo - App version info
- * @returns {Object} - Discord embed payload
- */
-export function createAppVersionEmbed(appInfo) {
-  const platformEmoji = appInfo.platform === 'android' ? '🤖' : '🍎';
-  const color = appInfo.platform === 'android' ? 0x3DDC84 : 0x5FC9F8;
-
-  const rawDescription = appInfo.description || 'No description available.';
-  const rawReleaseNotes = appInfo.recentChanges || 'No release notes available.';
-
-  const description = htmlToMarkdown(rawDescription);
-  const releaseNotes = htmlToMarkdown(rawReleaseNotes);
-
-  return safeEmbed({
-    username: 'App Version Watcher',
-    avatar_url: LOGO_URL,
-    embeds: [{
-      title: `${platformEmoji} ${appInfo.title} — v${appInfo.version}`,
-      url: appInfo.url,
-      description: truncate(description, 300),
-      color,
-      thumbnail: {
-        url: appInfo.icon
-      },
-      fields: [
-        {
-          name: '📝 Release Notes',
-          value: truncate(releaseNotes, 1000) || '(none)'
-        },
-        {
-          name: '🏢 Developer',
-          value: truncate(appInfo.developer || 'Unknown', 100),
-          inline: true
-        },
-        {
-          name: '📦 App ID',
-          value: `\`${truncate(appInfo.appId, 100)}\``,
-          inline: true
-        },
-        {
-          name: '🏬 Store',
-          value: appInfo.platform === 'android' ? 'Google Play' : 'App Store',
-          inline: true
-        }
-      ],
-      timestamp: new Date().toISOString(),
-      footer: {
-        text: `App Version Watcher \u2022 ${appInfo.platform.toUpperCase()}`,
-        icon_url: LOGO_URL
-      }
-    }]
-  });
-}
-
-/**
- * Create Discord embed(s) for a raw strings diff with red/green highlighting
- * Uses Discord ```diff code blocks so - lines are red and + lines are green
- * @param {string} appId - App package ID
- * @param {string} diffText - Raw diff text
- * @returns {Object} - Discord embed payload
- */
-// Organization color map for LM Arena
-const ORG_COLORS = {
-  openai: 0x10a37f,
-  anthropic: 0xd97757,
-  google: 0x4285f4,
-  xai: 0x1c1c1c,
-  meta: 0x0668e1,
-  mistral: 0xff7000,
-  cohere: 0xd18ee2,
-  deepseek: 0x4d6bfa,
-  alibaba: 0xff6a00,
-  baidu: 0x2932e1,
-  microsoft: 0x00a4ef,
-  amazon: 0xff9900,
-  default: 0x6366f1,
-};
-
-function getOrgColor(org) {
-  return ORG_COLORS[(org || '').toLowerCase()] || ORG_COLORS.default;
-}
-
-/**
- * Format a capability path like "inputCapabilities.image" into a readable label like "image input".
- */
-function formatCapPath(path) {
-  const map = {
-    'inputCapabilities.text': 'text input',
-    'inputCapabilities.image': 'image input',
-    'inputCapabilities.file': 'file input',
-    'inputCapabilities.video': 'video input',
-    'inputCapabilities.audio': 'audio input',
-    'outputCapabilities.text': 'text output',
-    'outputCapabilities.web': 'web output',
-    'outputCapabilities.image': 'image output',
-    'outputCapabilities.video': 'video output',
-    'outputCapabilities.search': 'search output',
-  };
-  return map[path] || path.replace(/Capabilities\./g, ' ').replace(/\./g, ' ');
-}
-
-/**
- * Extract capability emojis from a capabilities object
- * Handles both flat boolean structure and nested object structure
- * @param {Object} cap - Capabilities object with inputCapabilities and outputCapabilities
- * @returns {string} - Space-separated emoji string
- */
-export function capabilityEmoji(cap) {
-  const parts = [];
-  if (!cap) return '';
-  const inp = cap.inputCapabilities || {};
-  const out = cap.outputCapabilities || {};
-  if (inp.text) parts.push('📝');
-  if (inp.image) parts.push('🖼️');
-  if (inp.file) parts.push('📎');
-  if (out.text) parts.push('💬');
-  if (out.web) parts.push('🌐');
-  if (out.image) parts.push('🎨');
-  if (out.search) parts.push('🔍');
-  return parts.join(' ');
-}
-
-function modelLine(m) {
-  const rank = m.rank ? `#${m.rank}` : 'unranked';
-  const org = m.organization || 'unknown';
-  const caps = capabilityEmoji(m.capabilities);
-  const selectable = m.userSelectable ? '✅' : '🔒';
-  return `**${m.displayName || m.publicName || m.name}** \`${rank}\` | ${org} ${caps} ${selectable}`;
-}
-
-export function createLMArenaEmbed(diff, totalModels) {
-  const embeds = [];
-  const { groupDiff } = diff || {};
-
-  // Summary embed
-  const summaryEmbed = {
-    color: 0x8b5cf6,
-    title: '🏆 LM Arena Model Changes Detected',
-    description: `Total models tracked: **${totalModels}**`,
-    fields: [],
-    timestamp: new Date().toISOString(),
-    footer: {
-      text: 'LM Arena Watcher',
-      icon_url: LOGO_URL,
-    },
-  };
-
-  const addedStealth = diff.added.filter(m => !m.organization);
-  const addedKnown = diff.added.filter(m => m.organization);
-  if (addedStealth.length > 0) {
-    summaryEmbed.fields.push({
-      name: `🥷 New Stealth Models (${addedStealth.length})`,
-      value: addedStealth.length > 10
-        ? `${addedStealth.slice(0, 10).map(m => `• ${m.displayName || m.publicName}`).join('\n')}\n...and ${addedStealth.length - 10} more`
-        : addedStealth.map(m => `• ${m.displayName || m.publicName}`).join('\n'),
-      inline: true,
-    });
-  }
-  if (addedKnown.length > 0) {
-    summaryEmbed.fields.push({
-      name: `🆕 New Models (${addedKnown.length})`,
-      value: addedKnown.length > 10
-        ? `${addedKnown.slice(0, 10).map(m => `• ${m.displayName || m.publicName}`).join('\n')}\n...and ${addedKnown.length - 10} more`
-        : addedKnown.map(m => `• ${m.displayName || m.publicName}`).join('\n'),
-      inline: true,
-    });
-  }
-
-  if (diff.removed.length > 0) {
-    summaryEmbed.fields.push({
-      name: `🗑️ Removed Models (${diff.removed.length})`,
-      value: diff.removed.length > 10
-        ? `${diff.removed.slice(0, 10).map(m => `• ${m.displayName || m.publicName}`).join('\n')}\n...and ${diff.removed.length - 10} more`
-        : diff.removed.map(m => `• ${m.displayName || m.publicName}`).join('\n'),
-      inline: true,
-    });
-  }
-
-  if (diff.changed.length > 0) {
-    summaryEmbed.fields.push({
-      name: `🔄 Updated Models (${diff.changed.length})`,
-      value: diff.changed.length > 10
-        ? `${diff.changed.slice(0, 10).map(c => `• ${c.model.displayName || c.model.publicName}`).join('\n')}\n...and ${diff.changed.length - 10} more`
-        : diff.changed.map(c => `• ${c.model.displayName || c.model.publicName}`).join('\n'),
-      inline: true,
-    });
-  }
-
-  // Revealed models (gained organization)
-  if (diff.revealed && diff.revealed.length > 0) {
-    summaryEmbed.fields.push({
-      name: `🕵️ Revealed Models (${diff.revealed.length})`,
-      value: diff.revealed.slice(0, 10).map(r => {
-        const nameChange = r.oldName !== r.newName ? ` \`${r.oldName}\`` : '';
-        return `•${nameChange} → **${r.newName}** (${r.newOrg})`;
-      }).join('\n'),
-      inline: true,
-    });
-  }
-
-  // Possible reveals (stealth removed → new model with same caps)
-  if (diff.possibleReveals && diff.possibleReveals.length > 0) {
-    summaryEmbed.fields.push({
-      name: `🔎 Possible Reveals (${diff.possibleReveals.length})`,
-      value: diff.possibleReveals.slice(0, 10).map(pr =>
-        `• \`${pr.removed.displayName || pr.removed.publicName}\` → **${pr.added.displayName || pr.added.publicName}** (${pr.match})`
-      ).join('\n'),
-      inline: true,
-    });
-  }
-
-  // Group-level changes (variant counts, new groups, removed groups)
-  if (groupDiff) {
-    if (groupDiff.newGroups.length > 0) {
-      summaryEmbed.fields.push({
-        name: `📦 New Model Groups (${groupDiff.newGroups.length})`,
-        value: groupDiff.newGroups.slice(0, 10).map(g =>
-          `• ${g.displayName} (${g.profile.count} variant${g.profile.count > 1 ? 's' : ''})`
-        ).join('\n'),
-        inline: true,
-      });
-    }
-    if (groupDiff.removedGroups.length > 0) {
-      summaryEmbed.fields.push({
-        name: `📭 Removed Groups (${groupDiff.removedGroups.length})`,
-        value: groupDiff.removedGroups.slice(0, 10).map(g =>
-          `• ${g.displayName} (${g.profile.count} variant${g.profile.count > 1 ? 's' : ''})`
-        ).join('\n'),
-        inline: true,
-      });
-    }
-    if (groupDiff.variantChanges.length > 0) {
-      summaryEmbed.fields.push({
-        name: `🔀 Variant Changes (${groupDiff.variantChanges.length})`,
-        value: groupDiff.variantChanges.slice(0, 10).map(v =>
-          `• ${v.displayName}: ${v.oldCount} → ${v.newCount} variants`
-        ).join('\n'),
-        inline: true,
-      });
-    }
-    if (groupDiff.convergence.length > 0) {
-      summaryEmbed.fields.push({
-        name: `🎯 Capability Convergence (${groupDiff.convergence.length})`,
-        value: groupDiff.convergence.slice(0, 10).map(c =>
-          `• ${c.displayName}: **${c.allNowHave.map(formatCapPath).join(', ')}** now across all ${c.variantCount} variants`
-        ).join('\n'),
-        inline: true,
-      });
-    }
-  }
-
-  embeds.push(summaryEmbed);
-
-  // Detail embeds for new stealth models (no organization — potential future reveals)
-  if (addedStealth.length > 0) {
-    const lines = addedStealth.map(m => {
-      const caps = capabilityEmoji(m.capabilities);
-      return `**${m.displayName || m.publicName || m.name}**${caps ? ' ' + caps : ''} \`${m.rank ? '#' + m.rank : 'unranked'}\``;
-    });
-    let chunk = [];
-    let chunkLen = 0;
-    const chunks = [];
-    for (const line of lines) {
-      if (chunkLen + line.length > 900 && chunk.length > 0) {
-        chunks.push(chunk.join('\n'));
-        chunk = [line];
-        chunkLen = line.length;
-      } else {
-        chunk.push(line);
-        chunkLen += line.length + 1;
-      }
-    }
-    if (chunk.length) chunks.push(chunk.join('\n'));
-    for (let i = 0; i < chunks.length; i++) {
-      embeds.push({
-        color: 0x6b7280,
-        title: i === 0 ? `🥷 New Stealth Models` : `🥷 New Stealth Models (cont.)`,
-        description: chunks[i],
-        timestamp: new Date().toISOString(),
-      });
-    }
-  }
-
-  // Detail embeds for new known models (group by org)
-  if (addedKnown.length > 0) {
-    const byOrg = {};
-    for (const m of addedKnown) {
-      const org = m.organization || 'Unknown';
-      if (!byOrg[org]) byOrg[org] = [];
-      byOrg[org].push(m);
-    }
-
-    for (const [org, models] of Object.entries(byOrg)) {
-      const lines = models.map(modelLine);
-      // Split into chunks if needed (field value limit ~950)
-      let chunk = [];
-      let chunkLen = 0;
-      const chunks = [];
-      for (const line of lines) {
-        if (chunkLen + line.length > 900 && chunk.length > 0) {
-          chunks.push(chunk.join('\n'));
-          chunk = [line];
-          chunkLen = line.length;
-        } else {
-          chunk.push(line);
-          chunkLen += line.length + 1;
-        }
-      }
-      if (chunk.length) chunks.push(chunk.join('\n'));
-
-      for (let i = 0; i < chunks.length; i++) {
-        embeds.push({
-          color: getOrgColor(org),
-          title: i === 0 ? `🆕 New — ${org}` : `🆕 New — ${org} (cont.)`,
-          description: chunks[i],
-          timestamp: new Date().toISOString(),
-        });
-      }
-    }
-  }
-
-  // Detail embeds for removed models
-  if (diff.removed.length > 0) {
-    const byOrg = {};
-    for (const m of diff.removed) {
-      const org = m.organization || 'Unknown';
-      if (!byOrg[org]) byOrg[org] = [];
-      byOrg[org].push(m);
-    }
-
-    for (const [org, models] of Object.entries(byOrg)) {
-      const lines = models.map(m => `**${m.displayName || m.publicName || m.name}** \`${m.rank ? '#' + m.rank : 'unranked'}\``);
-      let chunk = [];
-      let chunkLen = 0;
-      const chunks = [];
-      for (const line of lines) {
-        if (chunkLen + line.length > 900 && chunk.length > 0) {
-          chunks.push(chunk.join('\n'));
-          chunk = [line];
-          chunkLen = line.length;
-        } else {
-          chunk.push(line);
-          chunkLen += line.length + 1;
-        }
-      }
-      if (chunk.length) chunks.push(chunk.join('\n'));
-
-      for (let i = 0; i < chunks.length; i++) {
-        embeds.push({
-          color: 0xef4444,
-          title: i === 0 ? `🗑️ Removed — ${org}` : `🗑️ Removed — ${org} (cont.)`,
-          description: chunks[i],
-          timestamp: new Date().toISOString(),
-        });
-      }
-    }
-  }
-
-  // Detail embeds for updated models
-  if (diff.changed.length > 0) {
-    const byOrg = {};
-    for (const c of diff.changed) {
-      const org = c.model.organization || 'Unknown';
-      if (!byOrg[org]) byOrg[org] = [];
-      byOrg[org].push(c);
-    }
-
-    for (const [org, changes] of Object.entries(byOrg)) {
-      const lines = changes.map(c => {
-        const m = c.model;
-        const changeStr = c.changes.join(', ');
-        return `**${m.displayName || m.publicName || m.name}**\n${changeStr}`;
-      });
-      let chunk = [];
-      let chunkLen = 0;
-      const chunks = [];
-      for (const line of lines) {
-        if (chunkLen + line.length > 900 && chunk.length > 0) {
-          chunks.push(chunk.join('\n'));
-          chunk = [line];
-          chunkLen = line.length;
-        } else {
-          chunk.push(line);
-          chunkLen += line.length + 1;
-        }
-      }
-      if (chunk.length) chunks.push(chunk.join('\n'));
-
-      for (let i = 0; i < chunks.length; i++) {
-        embeds.push({
-          color: 0xf59e0b,
-          title: i === 0 ? `🔄 Updated — ${org}` : `🔄 Updated — ${org} (cont.)`,
-          description: chunks[i],
-          timestamp: new Date().toISOString(),
-        });
-      }
-    }
-  }
-
-  // Detail embeds for revealed models
-  if (diff.revealed && diff.revealed.length > 0) {
-    for (const r of diff.revealed) {
-      const details = [];
-      details.push(`🆔 \`${r.model.id}\``);
-      if (r.oldName !== r.newName) {
-        details.push(`📛 Codename: \`${r.oldName}\` → **${r.newName}**`);
-      }
-      details.push(`🏢 Organization: **(none)** → **${r.newOrg}**`);
-      if (r.newProvider && r.oldProvider !== r.newProvider) {
-        details.push(`⚙️ Provider: ${r.oldProvider || '(none)'} → **${r.newProvider}**`);
-      }
-      if (r.oldSelectable !== r.newSelectable) {
-        details.push(`🔓 Selectable: ${r.oldSelectable ? '✅' : '🔒'} → ${r.newSelectable ? '✅' : '🔒'}`);
-      }
-      const caps = capabilityEmoji(r.model.capabilities);
-      if (caps) details.push(`🎯 Capabilities: ${caps}`);
-
-      embeds.push({
-        color: 0xf59e0b,
-        title: `🕵️ ${r.oldName} → ${r.newName} by ${r.newOrg}`,
-        description: details.join('\n'),
-        timestamp: new Date().toISOString(),
-      });
-    }
-  }
-
-  // Detail embeds for variant count changes
-  if (groupDiff && groupDiff.variantChanges.length > 0) {
-    for (const v of groupDiff.variantChanges) {
-      const oldRanks = v.oldRanks.length ? `ranks ${v.oldRanks.join(',')}` : 'no ranks';
-      const newRanks = v.newRanks.length ? `ranks ${v.newRanks.join(',')}` : 'no ranks';
-      let desc = `Variants: **${v.oldCount}** → **${v.newCount}**\nRanks: ${oldRanks} → ${newRanks}${v.newProviders.length ? `\nProviders: ${v.newProviders.join(', ')}` : ''}`;
-      // Append capability matrix if available
-      if (v.capMatrix && v.capMatrix.length > 0) {
-        desc += '\n\n**Capability matrix:**';
-        for (const cap of v.capMatrix) {
-          const pct = Math.round((cap.count / cap.total) * 100);
-          const bar = '█'.repeat(Math.round(pct / 10)) + '░'.repeat(10 - Math.round(pct / 10));
-          desc += `\n${cap.emoji} ${cap.label}: \`${bar}\` ${cap.count}/${cap.total}`;
-        }
-      }
-      embeds.push({
-        color: 0x8b5cf6,
-        title: `🔀 ${v.displayName}: ${v.oldCount} → ${v.newCount} variants`,
-        description: desc,
-        timestamp: new Date().toISOString(),
-      });
-    }
-  }
-
-  // Detail embeds for capability convergence
-  if (groupDiff && groupDiff.convergence.length > 0) {
-    for (const c of groupDiff.convergence) {
-      embeds.push({
-        color: 0x10b981,
-        title: `🎯 ${c.displayName} — Converged`,
-        description: `**${c.allNowHave.map(formatCapPath).join(', ')}** is now available across all **${c.variantCount}** variants.`,
-        timestamp: new Date().toISOString(),
-      });
-    }
-  }
-
-  // Detail embeds for possible reveals
-  if (diff.possibleReveals && diff.possibleReveals.length > 0) {
-    for (const pr of diff.possibleReveals) {
-      const rem = pr.removed;
-      const add = pr.added;
-      const remCaps = capabilityEmoji(rem.capabilities);
-      const addCaps = capabilityEmoji(add.capabilities);
-      embeds.push({
-        color: 0xf97316,
-        title: `🔎 ${rem.displayName || rem.publicName} → ${add.displayName || add.publicName}?`,
-        description: `**Removed:** \`${rem.displayName || rem.publicName}\` (stealth, no org)\n**Added:** **${add.displayName || add.publicName}**${add.organization ? ` (${add.organization})` : ''}\n**Match:** ${pr.match}\n**Capabilities:** ${remCaps} → ${addCaps}\n*(⚠️ not confirmed — same capabilities, different identity)*`,
-        timestamp: new Date().toISOString(),
-      });
-    }
-  }
-
-  // Hard-truncate the entire payload to 6000
-  return safeEmbed({
-    username: 'LM Arena Watcher',
-    avatar_url: LOGO_URL,
-    embeds,
-  });
-}
-
-export function createStringsDiffEmbed(appId, diffText) {
-  const MAX_FIELD_VALUE = 950; // Under Discord's 1024 field value limit, accounting for ```diff\n and \n```
-  const MAX_EMBEDS_PER_MESSAGE = 5; // Limit total embeds to stay under 6000 total chars
-
-  // Escape triple backticks to prevent breaking code blocks
-  const safeDiff = diffText.replace(/```/g, '`\u200b`\u200b`');
-  const lines = safeDiff.split('\n');
-
-  const chunks = [];
-  let currentChunk = [];
-  let currentLength = 0;
-
-  for (const line of lines) {
-    // +1 accounts for the newline character
-    if (currentLength + line.length + 1 > MAX_FIELD_VALUE && currentChunk.length > 0) {
-      chunks.push(currentChunk.join('\n'));
-      currentChunk = [line];
-      currentLength = line.length;
-    } else {
-      currentChunk.push(line);
-      currentLength += line.length + 1;
-    }
-  }
-
-  if (currentChunk.length > 0) {
-    chunks.push(currentChunk.join('\n'));
-  }
-
-  // If we have too many chunks, truncate and add a note
-  const wasTruncated = chunks.length > MAX_EMBEDS_PER_MESSAGE;
-  const displayChunks = chunks.slice(0, MAX_EMBEDS_PER_MESSAGE);
-  const totalChunks = chunks.length;
-
-  const embeds = [];
-
-  for (let i = 0; i < displayChunks.length; i++) {
-    const isFirst = i === 0;
-    const isLast = i === displayChunks.length - 1;
-
-    let value = '```diff\n' + displayChunks[i] + '\n```';
-    if (isLast && wasTruncated) {
-      value += `\n*(diff truncated: ${totalChunks - MAX_EMBEDS_PER_MESSAGE} more chunks)*`;
-    }
-
-    const embed = {
-      color: 0x3B82F6,
-      fields: [{
-        name: totalChunks > 1 ? `Diff (${i + 1}/${totalChunks})` : 'Diff',
-        value
-      }],
-      timestamp: new Date().toISOString()
-    };
-
-    if (isFirst) {
-      embed.title = `\ud83d\udcf1 ${appId} — Strings Changed`;
-      embed.description = 'Android app strings diff detected';
-    }
-
-    if (isLast) {
-      embed.footer = {
-        text: 'Android Strings Watcher',
-        icon_url: LOGO_URL
-      };
-    }
-
-    embeds.push(embed);
-  }
-
-  return safeEmbed({
-    username: 'Android Strings Watcher',
-    avatar_url: LOGO_URL,
-    embeds
-  });
 }


### PR DESCRIPTION
This PR addresses several vulnerabilities related to Discord webhook payload limits:

1. **AWS Bedrock (`src/bedrock-watch.js`)**: Now tracks line lengths and partitions content into multiple `type: 10` components if they exceed 2000 characters.
2. **Regex Watcher (`src/regex-watch.js`)**: Truncates the pattern `value` in `createMatchesEmbed` to 1000 characters.
3. **Webhook Helpers (`src/webhook.js`)**: 
   - Introduced a `safeEmbed` helper that hard-truncates all embed fields (title, description, fields, footer) to their respective Discord limits.
   - Ensures the total character count across all embeds in a single message does not exceed 6000 characters.
   - `createSummaryEmbed` and `createLMArenaEmbed` now use `safeEmbed` to guarantee compliance.
   - `createAppVersionEmbed` now truncates release notes to 1000 characters to leave a safety margin.

These changes ensure robust delivery of Discord notifications even when large volumes of model changes or regex matches are detected.